### PR TITLE
feat: add two-level work mode (projectExecution + roleExecution)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,10 +30,10 @@ const plugin = {
           qa: { type: "string", description: "QA engineer model" },
         },
       },
-      workMode: {
+      projectExecution: {
         type: "string",
         enum: ["parallel", "sequential"],
-        description: "Work mode: parallel (each project independent) or sequential (1 DEV + 1 QA globally)",
+        description: "Plugin-level project execution: parallel (each project independent) or sequential (only one project active at a time)",
         default: "parallel",
       },
       orchestratorDm: {

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -23,6 +23,8 @@ export type Project = {
   baseBranch: string;
   deployBranch: string;
   autoChain: boolean;
+  /** Project-level role execution: parallel (DEV+QA can run simultaneously) or sequential (only one role at a time). Default: parallel */
+  roleExecution?: "parallel" | "sequential";
   maxDevWorkers?: number;
   maxQaWorkers?: number;
   dev: WorkerState;

--- a/lib/setup.ts
+++ b/lib/setup.ts
@@ -32,6 +32,8 @@ export type SetupOpts = {
   workspacePath?: string;
   /** Model overrides per tier. Missing tiers use defaults. */
   models?: Partial<Record<Tier, string>>;
+  /** Plugin-level project execution mode: parallel or sequential. Default: parallel. */
+  projectExecution?: "parallel" | "sequential";
 };
 
 export type SetupResult = {
@@ -110,7 +112,7 @@ export async function runSetup(opts: SetupOpts): Promise<SetupResult> {
   }
 
   // Write plugin config to openclaw.json (includes agentId in devClawAgentIds)
-  await writePluginConfig(models, agentId);
+  await writePluginConfig(models, agentId, opts.projectExecution);
 
   // --- Step 3: Workspace files ---
 
@@ -284,6 +286,7 @@ async function resolveWorkspacePath(agentId: string): Promise<string> {
 async function writePluginConfig(
   models: Record<Tier, string>,
   agentId?: string,
+  projectExecution?: "parallel" | "sequential",
 ): Promise<void> {
   const configPath = path.join(
     process.env.HOME ?? "/home/lauren",
@@ -302,6 +305,11 @@ async function writePluginConfig(
 
   // Write models
   config.plugins.entries.devclaw.config.models = { ...models };
+
+  // Write projectExecution if specified
+  if (projectExecution) {
+    config.plugins.entries.devclaw.config.projectExecution = projectExecution;
+  }
 
   // Configure subagent cleanup interval to 30 days (43200 minutes)
   // This keeps development sessions alive during active development

--- a/lib/tools/devclaw-setup.ts
+++ b/lib/tools/devclaw-setup.ts
@@ -41,6 +41,11 @@ export function createSetupTool(api: OpenClawPluginApi) {
             qa: { type: "string", description: `QA engineer model (default: ${DEFAULT_MODELS.qa})` },
           },
         },
+        projectExecution: {
+          type: "string",
+          enum: ["parallel", "sequential"],
+          description: "Plugin-level project execution mode: parallel (each project independent) or sequential (work on one project at a time). Default: parallel.",
+        },
       },
     },
 
@@ -49,6 +54,7 @@ export function createSetupTool(api: OpenClawPluginApi) {
       const channelBinding = params.channelBinding as "telegram" | "whatsapp" | undefined;
       const migrateFrom = params.migrateFrom as string | undefined;
       const modelsParam = params.models as Partial<Record<Tier, string>> | undefined;
+      const projectExecution = params.projectExecution as "parallel" | "sequential" | undefined;
       const workspaceDir = ctx.workspaceDir;
 
       const result = await runSetup({
@@ -59,6 +65,7 @@ export function createSetupTool(api: OpenClawPluginApi) {
         agentId: newAgentName ? undefined : ctx.agentId,
         workspacePath: newAgentName ? undefined : workspaceDir,
         models: modelsParam,
+        projectExecution,
       });
 
       const lines = [

--- a/lib/tools/project-register.ts
+++ b/lib/tools/project-register.ts
@@ -106,6 +106,11 @@ export function createProjectRegisterTool(api: OpenClawPluginApi) {
           type: "string",
           description: "Deployment URL for the project",
         },
+        roleExecution: {
+          type: "string",
+          enum: ["parallel", "sequential"],
+          description: "Project-level role execution mode: parallel (DEV and QA can work simultaneously) or sequential (only one role active at a time). Defaults to parallel.",
+        },
       },
     },
 
@@ -117,6 +122,7 @@ export function createProjectRegisterTool(api: OpenClawPluginApi) {
       const baseBranch = params.baseBranch as string;
       const deployBranch = (params.deployBranch as string) ?? baseBranch;
       const deployUrl = (params.deployUrl as string) ?? "";
+      const roleExecution = (params.roleExecution as "parallel" | "sequential") ?? "parallel";
       const workspaceDir = ctx.workspaceDir;
 
       if (!workspaceDir) {
@@ -199,6 +205,7 @@ export function createProjectRegisterTool(api: OpenClawPluginApi) {
         baseBranch,
         deployBranch,
         autoChain: false,
+        roleExecution,
         dev: emptyWorkerState([...DEV_TIERS]),
         qa: emptyWorkerState([...QA_TIERS]),
       };

--- a/lib/tools/task-pickup.ts
+++ b/lib/tools/task-pickup.ts
@@ -229,6 +229,18 @@ export function createTaskPickupTool(api: OpenClawPluginApi) {
         );
       }
 
+      // 6b. Check project-level roleExecution
+      const roleExecution = project.roleExecution ?? "parallel";
+      if (roleExecution === "sequential") {
+        const otherRole = role === "dev" ? "qa" : "dev";
+        const otherWorker = getWorker(project, otherRole);
+        if (otherWorker.active) {
+          throw new Error(
+            `Project "${project.name}" has sequential roleExecution: ${otherRole.toUpperCase()} worker is active (issue: ${otherWorker.issueId}). Wait for it to complete first.`,
+          );
+        }
+      }
+
       // 7. Select model (priority: param > tier label > heuristic)
       const targetLabel: StateLabel = role === "dev" ? "Doing" : "Testing";
       let modelAlias: string;


### PR DESCRIPTION
## Summary
Replaces single ambiguous `workMode` with two distinct, orthogonal settings.

## Two-Level Work Mode

### 1. Plugin-level `projectExecution` (openclaw.json)
Controls whether multiple **projects** can have active workers simultaneously.

| Mode | Behavior |
|------|----------|
| `parallel` | Each project independent — multiple projects can have workers running |
| `sequential` | Only one project can have active workers at a time |

### 2. Project-level `roleExecution` (projects.json)
Controls whether DEV and QA can run simultaneously **within the same project**.

| Mode | Behavior |
|------|----------|
| `parallel` | DEV and QA can work simultaneously on the same project |
| `sequential` | Only one role (DEV or QA) active at a time per project |

## Configuration Examples

**Plugin config (openclaw.json):**
```json
{
  "plugins": {
    "devclaw": {
      "config": {
        "projectExecution": "parallel"
      }
    }
  }
}
```

**Project config (projects.json):**
```json
{
  "projects": {
    "-123456": {
      "name": "my-project",
      "roleExecution": "sequential"
    }
  }
}
```

## Changes

- `index.ts`: Rename `workMode` → `projectExecution` in config schema
- `projects.ts`: Add `roleExecution` field to Project type
- `heartbeat_tick`: Check both levels before picking up tasks
- `task_pickup`: Enforce `roleExecution` when picking up manually
- `project_register`: Accept `roleExecution` param (default: parallel)
- `devclaw_setup`: Accept `projectExecution` param

## Backward Compatibility
All defaults remain `parallel`, matching previous behavior.

Closes #15