### PR TITLE
fix: re-throw error when state update fails after dispatch (#23)

### DIFF
--- a/lib/dispatch.ts
+++ b/lib/dispatch.ts
@@ -226,6 +226,10 @@ export async function dispatchTask(
         error: (err as Error).message,
         sessionKey,
       });
+      // Re-throw so caller knows state update failed
+      throw new Error(
+        `State update failed after successful session dispatch: ${(err as Error).message}. Session is running but projects.json was not updated.`,
+      );
     } else {
       // Dispatch failed — rollback label
       try {


### PR DESCRIPTION
## Problem
When a worker session is successfully dispatched but `activateWorker` fails to update `projects.json`, the error was being logged but not re-thrown. This caused `task_pickup` to return success even though the state wasn't updated, leading to `task_complete` failures later.

## Solution
Re-throw the error after logging the warning, so the caller knows the state update failed even though the session is running.

## Changes
- Modified `lib/dispatch.ts` to re-throw error when `dispatched = true` but `activateWorker` fails
- Added detailed error message explaining the situation

## Testing
- TypeScript type check (no tests available)
- Manual code review

Fixes #23