### PR TITLE
fix: remove GitHub auto-closing keywords from worker templates (#24)

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -8,6 +8,7 @@ export const DEFAULT_DEV_INSTRUCTIONS = `# DEV Worker Instructions
 - Work in a git worktree (never switch branches in the main repo)
 - Run tests before completing
 - Create an MR/PR to the base branch and merge it
+- **IMPORTANT:** Do NOT use closing keywords in PR/MR descriptions (no "Closes #X", "Fixes #X", "Resolves #X"). Instead use "As described in issue #X" or "Addresses issue #X". DevClaw manages issue state via task_complete - auto-closing bypasses QA validation.
 - Clean up the worktree after merging
 - When done, call task_complete with role "dev", result "done", and a brief summary
 - If you discover unrelated bugs, call task_create to file them
@@ -41,6 +42,7 @@ Skip the orchestrator section. Follow your task message and role instructions (a
 - Branch naming: \`feature/<id>-<slug>\` or \`fix/<id>-<slug>\`
 - **DEV always works in a git worktree** (never switch branches in the main repo)
 - **DEV must merge to base branch** before announcing completion
+- **Do NOT use closing keywords in PR/MR descriptions** (no "Closes #X", "Fixes #X", "Resolves #X"). Instead use "As described in issue #X" or "Addresses issue #X". DevClaw manages issue state via task_complete — auto-closing bypasses QA validation.
 - **QA tests on the deployed version** and inspects code on the base branch
 - Always run tests before completing
 


### PR DESCRIPTION
As described in issue #24

## Changes

- Added explicit warning to DEFAULT_DEV_INSTRUCTIONS in templates.ts
- Added warning to AGENTS_MD_TEMPLATE conventions section
- Workers now instructed to use 'As described in issue #X' or 'Addresses issue #X' instead of 'Closes #X', 'Fixes #X', 'Resolves #X'

## Why

DEV workers were including GitHub/GitLab closing keywords in PR descriptions, causing issues to auto-close when PRs merged. This bypassed DevClaw's state management:
- Labels should transition Doing → Done via task_complete
- QA should validate before closing
- projects.json should stay in sync

## Testing

- Reviewed templates.ts changes
- Verified no TypeScript syntax errors in string literals
- Confirmed instructions are clear and actionable