### PR TITLE
Fix: Persist sessions per tier for reuse

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { createTaskPickupTool } from "./lib/tools/task-pickup.js";
 import { createTaskCompleteTool } from "./lib/tools/task-complete.js";
 import { createQueueStatusTool } from "./lib/tools/queue-status.js";
 import { createSessionHealthTool } from "./lib/tools/session-health.js";
+import { createSessionCleanupTool } from "./lib/tools/session-cleanup.js";
 
 const plugin = {
   id: "devclaw",
@@ -25,8 +26,11 @@ const plugin = {
     api.registerTool(createSessionHealthTool(api), {
       names: ["session_health"],
     });
+    api.registerTool(createSessionCleanupTool(api), {
+      names: ["session_cleanup"],
+    });
 
-    api.logger.info("DevClaw plugin registered (4 tools)");
+    api.logger.info("DevClaw plugin registered (5 tools)");
   },
 };
 

--- a/lib/tools/queue-status.ts
+++ b/lib/tools/queue-status.ts
@@ -64,12 +64,16 @@ export function createQueueStatusTool(api: OpenClawPluginApi) {
           dev: {
             active: project.dev.active,
             sessionId: project.dev.sessionId,
+            tier: project.dev.tier,
+            sessions: project.dev.sessions,
             issueId: project.dev.issueId,
             model: project.dev.model,
           },
           qa: {
             active: project.qa.active,
             sessionId: project.qa.sessionId,
+            tier: project.qa.tier,
+            sessions: project.qa.sessions,
             issueId: project.qa.issueId,
             model: project.qa.model,
           },

--- a/lib/tools/session-cleanup.ts
+++ b/lib/tools/session-cleanup.ts
@@ -1,0 +1,80 @@
+/**
+ * session_cleanup — Clear tier sessions for a worker.
+ *
+ * Use this when you want to explicitly remove a session (e.g., after
+ * prolonged inactivity, or to force a fresh spawn for the next task).
+ */
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import { readProjects, updateWorker } from "../projects.js";
+import { log as auditLog } from "../audit.js";
+
+export function createSessionCleanupTool(api: OpenClawPluginApi) {
+  return (ctx: OpenClawPluginToolContext) => ({
+    name: "session_cleanup",
+    description: `Clear tier sessions for a DEV or QA worker. Use to remove stale sessions or force fresh spawns. Clears all tier sessions for the worker, or a specific tier if specified.`,
+    parameters: {
+      type: "object",
+      required: ["role", "projectGroupId"],
+      properties: {
+        role: { type: "string", enum: ["dev", "qa"], description: "Worker role: dev or qa" },
+        projectGroupId: { type: "string", description: "Telegram group ID (key in projects.json)" },
+        tier: { type: "string", description: "Specific tier to clear (e.g. haiku, sonnet, opus, grok). Omit to clear all tiers." },
+        clearAll: { type: "boolean", description: "Clear all session data including legacy sessionId. Default: false (only clears tier sessions)." },
+      },
+    },
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const role = params.role as "dev" | "qa";
+      const groupId = params.projectGroupId as string;
+      const tier = params.tier as string | undefined;
+      const clearAll = (params.clearAll as boolean) ?? false;
+      const workspaceDir = ctx.workspaceDir;
+
+      if (!workspaceDir) {
+        throw new Error("No workspace directory available in tool context");
+      }
+
+      const data = await readProjects(workspaceDir);
+      const project = data.projects[groupId];
+      if (!project) {
+        throw new Error(`Project not found for groupId: ${groupId}`);
+      }
+
+      const worker = project[role];
+      const updates: Record<string, unknown> = {};
+
+      if (tier) {
+        // Clear specific tier
+        updates.sessions = { ...worker.sessions, [tier]: null };
+      } else if (clearAll) {
+        // Clear everything including legacy sessionId
+        updates.sessions = {};
+        updates.sessionId = null;
+      } else {
+        // Clear all tier sessions but keep legacy sessionId
+        updates.sessions = {};
+      }
+
+      await updateWorker(workspaceDir, groupId, role, updates);
+
+      const message = tier
+        ? `Cleared ${role.toUpperCase()} tier "${tier}" session for ${project.name}`
+        : clearAll
+          ? `Cleared all sessions for ${role.toUpperCase()} on ${project.name}`
+          : `Cleared all tier sessions for ${role.toUpperCase()} on ${project.name}`;
+
+      // Audit log
+      await auditLog(workspaceDir, "session_cleanup", {
+        project: project.name,
+        groupId,
+        role,
+        tier: tier ?? null,
+        clearAll,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ success: true, message }, null, 2) }],
+      };
+    },
+  });
+}


### PR DESCRIPTION
As described in issue #27

## Changes

- Add tier-based session storage to WorkerState (sessions field)
- Update task_pickup to check for and reuse tier-specific sessions  
- Update task_complete to preserve tier sessions when deactivating
- Add session_cleanup tool for explicit session removal
- Update session_health to handle tier sessions and detect stale ones
- Update queue_status to display tier session information

## Why This Matters

Sessions now persist per tier (haiku/sonnet/opus/grok) after task completion, enabling:
- **Performance:** Avoid spawning new sessions for every task
- **Context preservation:** Session retains context from previous work
- **Resource efficiency:** Subagent cleanup interval keeps them alive anyway

## Testing

Manual testing required to verify:
1. Worker completes task → tier session persists in projects.json
2. Same tier picks up new task → reuses existing session
3. Different tier picks up task → spawns new session
4. session_cleanup tool can explicitly remove sessions when needed