### PR TITLE
feat: enhance notification URLs with issue links and tool aliases

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,10 +65,10 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     // Agent tools (primary interface — agent calls these directly)
     api.registerTool(createTaskPickupTool(api), {
-      names: ["task_pickup"],
+      names: ["task_pickup", "work_start"],
     });
     api.registerTool(createTaskCompleteTool(api), {
-      names: ["task_complete"],
+      names: ["task_complete", "work_finish"],
     });
     api.registerTool(createTaskUpdateTool(api), {
       names: ["task_update"],
@@ -77,7 +77,7 @@ const plugin = {
       names: ["task_comment"],
     });
     api.registerTool(createQueueStatusTool(api), {
-      names: ["queue_status"],
+      names: ["queue_status", "status"],
     });
     api.registerTool(createSessionHealthTool(api), {
       names: ["session_health"],


### PR DESCRIPTION
## Summary

Enhances DevClaw notifications to include issue URLs for better traceability, and adds tool name aliases to match documentation.

## Problem

Current notifications don't consistently include URLs to the actual issue or PR/MR, making it harder to:
- Jump directly to the code changes
- Trace work back to requirements
- Quickly verify what was done

Additionally, documentation (AGENTS.md) uses different tool names than the actual implementations.

## Solution

### 1. Enhanced DEV Completion Notifications

**Before:**
```
✅ DEV done #106 — Enhanced notification URLs
🔗 PR: https://github.com/user/repo/pull/107
. Moved to QA queue.
```

**After:**
```
✅ DEV done #106 — Enhanced notification URLs
📋 Issue: https://github.com/user/repo/issues/106
🔗 PR: https://github.com/user/repo/pull/107
Moved to QA queue.
```

**Changes:**
- Always includes issue URL (📋 Issue)
- Includes PR/MR URL when available (🔗 PR)
- Issue URL serves as fallback when PR/MR not found
- Both URLs shown for maximum traceability
- Cleaner formatting (removed extra period)

### 2. Enhanced QA Pass Notifications

**Before:**
```
🎉 QA PASS #106 — All tests passed. Issue closed.
```

**After:**
```
🎉 QA PASS #106 — All tests passed
📋 Issue: https://github.com/user/repo/issues/106
Issue closed.
```

**Changes:**
- Now includes issue URL
- Provides direct link to resolved issue

### 3. Tool Aliases

Added aliases to match AGENTS.md documentation:
- `work_finish` → alias for `task_complete`
- `work_start` → alias for `task_pickup`
- `status` → alias for `queue_status`

This allows workers to use either name (documented or implementation).

## Benefits

1. **Better Traceability**: One click to jump from notification to issue/PR
2. **Maximum Context**: Both issue AND PR links when available
3. **Graceful Fallback**: Issue URL always shown, PR URL when found
4. **Documentation Alignment**: Tool names match what workers are told to use
5. **Cleaner Format**: Improved readability with better line breaks

## Technical Changes

**Files Modified:**
- `lib/tools/task-complete.ts`: Enhanced DEV and QA announcement formatting
- `index.ts`: Added tool name aliases

## Acceptance Criteria

- ✅ DEV work_finish notifications include PR/MR URL
- ✅ Fallback to task URL when PR/MR unavailable
- ✅ QA pass notifications include task URL
- ✅ Notifications are clear and actionable
- ✅ Tool aliases match documentation

## Testing

Manual testing steps:
1. Complete a DEV task with merged PR → verify both issue and PR URLs shown
2. Complete a DEV task without PR → verify issue URL shown
3. Complete a QA task → verify issue URL shown
4. Call tools using aliases (`work_finish`, `work_start`, `status`) → verify they work

As described in issue #106