### PR TITLE
feat: auto-share ticket URL after task_create

### DIFF
--- a/lib/tools/task-create.ts
+++ b/lib/tools/task-create.ts
@@ -114,6 +114,19 @@ The issue is created with a state label (defaults to "Planning"). Returns the cr
 
       // 5. Build response
       const hasBody = description && description.trim().length > 0;
+      
+      // Build announcement with URL
+      let announcement = `📋 Created #${issue.iid}: "${title}" (${label})`;
+      if (hasBody) {
+        announcement += "\nWith detailed description.";
+      }
+      announcement += `\n🔗 ${issue.web_url}`;
+      if (pickup) {
+        announcement += "\nPicking up for DEV...";
+      } else {
+        announcement += "\nReady for pickup when needed.";
+      }
+      
       const result = {
         success: true,
         issue: {
@@ -126,9 +139,7 @@ The issue is created with a state label (defaults to "Planning"). Returns the cr
         project: project.name,
         provider: providerType,
         pickup,
-        announcement: pickup
-          ? `📋 Created #${issue.iid}: "${title}" (${label}).${hasBody ? " With detailed description." : ""} Picking up for DEV...`
-          : `📋 Created #${issue.iid}: "${title}" (${label}).${hasBody ? " With detailed description." : ""} Ready for pickup when needed.`,
+        announcement,
       };
 
       return jsonResult(result);


### PR DESCRIPTION
## Summary

Automatically includes the issue URL in the announcement when `task_create` is called, eliminating the need for users to explicitly ask "What's the URL?" after creating a task.

## Problem

When `task_create` was called, the URL was returned in the tool response but not automatically shared with the user. Users had to ask "What's the URL?" to get it, which added friction to the workflow.

## Solution

Modified the `task_create` tool to include the issue URL directly in the announcement field, which is automatically displayed to the user.

### Changes

**File:** `lib/tools/task-create.ts`

- Enhanced announcement formatting with line breaks for better readability
- Always includes issue URL with 🔗 prefix
- Structured format that clearly shows:
  - Issue number and title
  - State label
  - Whether description was provided (optional)
  - Issue URL (always)
  - Next action (pickup status)

## Example Output

### Simple task creation:
```
📋 Created #109: "Fix login bug" (To Do)
🔗 https://github.com/laurentenhoor/devclaw/issues/109
Ready for pickup when needed.
```

### Task with description:
```
📋 Created #110: "Add dark mode" (Planning)
With detailed description.
🔗 https://github.com/laurentenhoor/devclaw/issues/110
Ready for pickup when needed.
```

### Task with immediate pickup:
```
📋 Created #111: "Implement auth" (To Do)
With detailed description.
🔗 https://github.com/laurentenhoor/devclaw/issues/111
Picking up for DEV...
```

## Benefits

1. **Immediate Access**: Users get the URL right away without asking
2. **Better UX**: No additional interaction needed
3. **Code-level Fix**: Implemented in the tool itself, not just instructions
4. **Consistent Format**: All task creations now show URLs in the same way
5. **Improved Readability**: Multi-line format is clearer than single line

## Implementation Notes

- The URL was already in the tool response (`result.issue.url`)
- We just needed to surface it in the `announcement` field
- No API changes - maintains backward compatibility
- The announcement is automatically displayed to users by OpenClaw

## Testing

Manual testing:
1. Call `task_create` with just a title → URL appears automatically
2. Call `task_create` with title + description → URL appears with "With detailed description" note
3. Call `task_create` with `pickup: true` → URL appears with "Picking up for DEV..." message

## Acceptance Criteria

- ✅ After `task_create` succeeds, automatically share the issue URL with the user
- ✅ No additional user prompt required
- ✅ Kept the implementation in code, not instructions

As described in issue #109