### PR TITLE
fix: reset startTime on task assignment for accurate duration tracking

### DIFF
--- a/lib/dispatch.ts
+++ b/lib/dispatch.ts
@@ -244,12 +244,13 @@ async function recordWorkerState(
   workspaceDir: string, groupId: string, role: "dev" | "qa",
   opts: { issueId: number; tier: string; sessionKey: string; sessionAction: "spawn" | "send" },
 ): Promise<void> {
-  const params: { issueId: string; tier: string; sessionKey?: string; startTime?: string } = {
-    issueId: String(opts.issueId), tier: opts.tier,
+  const params: { issueId: string; tier: string; sessionKey?: string; startTime: string } = {
+    issueId: String(opts.issueId),
+    tier: opts.tier,
+    startTime: new Date().toISOString(), // Always reset startTime for new task assignment
   };
   if (opts.sessionAction === "spawn") {
     params.sessionKey = opts.sessionKey;
-    params.startTime = new Date().toISOString();
   }
   await activateWorker(workspaceDir, groupId, role, params);
 }


### PR DESCRIPTION
## Summary

Fixes stale worker detection showing incorrect durations when sessions are reused. The startTime now accurately reflects when the worker started the **current task**, not when the session was originally created.

## Problem

### Observed Behavior
- Session created 13 hours ago for issue #71
- Session reused 4 minutes ago for issue #106
- Status incorrectly showed: "DEV active on #106 (3.3h)"
- Health check flagged as stale: "DEV has been running for 3.3 hours"

### Expected Behavior
- Should show: "DEV active on #106 (4m)"
- Should not flag as stale until 2+ hours on current task

## Root Cause

In `lib/dispatch.ts`, the `recordWorkerState()` function only set `startTime` when spawning a new session:

```typescript
if (opts.sessionAction === "spawn") {
  params.sessionKey = opts.sessionKey;
  params.startTime = new Date().toISOString();  // Only set on spawn
}
```

When reusing an existing session (`sessionAction === "send"`), the old `startTime` from the previous task persisted in `projects.json`. The health check then calculated duration based on this stale timestamp, causing false positives for stale worker detection.

## Solution

Always set `startTime` when activating a worker, regardless of session action:

```typescript
const params = {
  issueId: String(opts.issueId),
  tier: opts.tier,
  startTime: new Date().toISOString(), // Always reset for new task
};
if (opts.sessionAction === "spawn") {
  params.sessionKey = opts.sessionKey;  // Only set sessionKey on spawn
}
```

The `startTime` field now consistently represents "when did this worker start **THIS specific task**" rather than "when was the session created".

## Changes

**File:** `lib/dispatch.ts`
- Moved `startTime` assignment outside the spawn-only conditional
- `startTime` now set unconditionally for both spawn and send actions
- Maintains backward compatibility with existing health checks
- Only 3 lines changed (moved 1 line out of conditional)

## Testing

### Manual Verification
1. Complete a task with a dev worker (creates session)
2. Immediately pick up a new task (reuses session)
3. Check status → duration should show minutes, not hours
4. Wait 5 minutes, check again → should show ~5 minutes
5. Session health should not flag as stale

### Affected Flows
- ✅ New session spawn: startTime set correctly
- ✅ Session reuse: startTime now resets correctly
- ✅ Stale worker detection: uses accurate task duration
- ✅ Status display: shows time on current task
- ✅ Health checks: no false positives for recently-started tasks

## Impact

### Before
- Stale worker detection used total session lifetime
- Session reuse caused false positive stale alerts
- Duration shown was misleading (hours instead of minutes)
- Health checks would incorrectly flag recently-started tasks

### After
- Duration reflects actual time on current task
- Session reuse properly resets task timer
- Stale worker detection only flags genuinely long-running tasks
- Status and health checks show accurate information

## Acceptance Criteria

- ✅ Worker duration reflects time since current task assignment, not total session age
- ✅ Stale worker detection doesn't flag recently-started tasks
- ✅ Session reuse properly resets task-specific timers

## Related

- Issue #108: Stale worker detection shows incorrect duration with session reuse

As described in issue #108