### PR TITLE
fix: clear startTime when deactivating workers to prevent stale timestamps

### DIFF
--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -230,6 +230,7 @@ export async function activateWorker(
 /**
  * Mark a worker as inactive after task completion.
  * Preserves sessions map and tier for reuse via updateWorker's spread.
+ * Clears startTime to prevent stale timestamps on inactive workers.
  */
 export async function deactivateWorker(
   workspaceDir: string,
@@ -239,6 +240,7 @@ export async function deactivateWorker(
   return updateWorker(workspaceDir, groupId, role, {
     active: false,
     issueId: null,
+    startTime: null,
   });
 }
 

--- a/lib/services/health.ts
+++ b/lib/services/health.ts
@@ -74,7 +74,7 @@ export async function checkWorkerHealth(opts: {
       fixed: false,
     };
     if (autoFix) {
-      await updateWorker(workspaceDir, groupId, role, { active: false, issueId: null });
+      await updateWorker(workspaceDir, groupId, role, { active: false, issueId: null, startTime: null });
       fix.fixed = true;
     }
     fixes.push(fix);
@@ -95,7 +95,7 @@ export async function checkWorkerHealth(opts: {
       await revertIssueLabel(fix);
       const sessions = { ...worker.sessions };
       if (worker.tier) sessions[worker.tier] = null;
-      await updateWorker(workspaceDir, groupId, role, { active: false, issueId: null, sessions });
+      await updateWorker(workspaceDir, groupId, role, { active: false, issueId: null, startTime: null, sessions });
       fix.fixed = true;
     }
     fixes.push(fix);
@@ -135,7 +135,7 @@ export async function checkWorkerHealth(opts: {
       };
       if (autoFix) {
         await revertIssueLabel(fix);
-        await updateWorker(workspaceDir, groupId, role, { active: false, issueId: null });
+        await updateWorker(workspaceDir, groupId, role, { active: false, issueId: null, startTime: null });
         fix.fixed = true;
       }
       fixes.push(fix);


### PR DESCRIPTION
## Summary

Fixes stale `startTime` values persisting on inactive workers by ensuring `startTime` is cleared to `null` when workers are deactivated.

## Problem

### Observed Behavior
When workers were deactivated (task completed or fixed by health checks), the `startTime` field was not being cleared. This caused:

- **Stale data**: Inactive workers retained old timestamps
- **Misleading metrics**: Duration calculations included inactive time
- **Data inconsistency**: Active state didn't match timestamp state

### Example from projects.json:
```json
{
  "qa": {
    "active": false,
    "issueId": null,
    "startTime": "2026-02-10T08:51:50.725Z",  // Stale timestamp!
    "tier": "qa"
  }
}
```

The QA worker is inactive but still has a startTime from 8 hours ago.

## Root Cause

### deactivateWorker() function
Only cleared active state and issueId:
```typescript
export async function deactivateWorker(...) {
  return updateWorker(workspaceDir, groupId, role, {
    active: false,
    issueId: null,
    // startTime NOT cleared!
  });
}
```

### Health check auto-fixes
Three code paths that deactivated workers also failed to clear `startTime`:
1. `active_no_session` fix
2. `zombie_session` fix
3. `stale_worker` fix

All three set `active: false` and `issueId: null` but left `startTime` intact.

## Solution

Always set `startTime: null` when deactivating a worker to ensure clean state.

## Changes

### 1. lib/projects.ts

**Updated `deactivateWorker()`:**
```typescript
export async function deactivateWorker(...) {
  return updateWorker(workspaceDir, groupId, role, {
    active: false,
    issueId: null,
    startTime: null,  // ✅ Now cleared
  });
}
```

**Updated function comment:**
- Documents that startTime is cleared to prevent stale timestamps

### 2. lib/services/health.ts

**Updated all three auto-fix paths:**

**Before:**
```typescript
// active_no_session fix
await updateWorker(workspaceDir, groupId, role, { 
  active: false, 
  issueId: null 
});

// zombie_session fix
await updateWorker(workspaceDir, groupId, role, { 
  active: false, 
  issueId: null, 
  sessions 
});

// stale_worker fix
await updateWorker(workspaceDir, groupId, role, { 
  active: false, 
  issueId: null 
});
```

**After:**
```typescript
// active_no_session fix
await updateWorker(workspaceDir, groupId, role, { 
  active: false, 
  issueId: null, 
  startTime: null  // ✅ Cleared
});

// zombie_session fix
await updateWorker(workspaceDir, groupId, role, { 
  active: false, 
  issueId: null, 
  startTime: null,  // ✅ Cleared
  sessions 
});

// stale_worker fix
await updateWorker(workspaceDir, groupId, role, { 
  active: false, 
  issueId: null, 
  startTime: null  // ✅ Cleared
});
```

## Impact

### Before
- ❌ Inactive workers had stale startTime values
- ❌ Duration calculations could include inactive time
- ❌ Data inconsistency between active and startTime fields
- ❌ Confusing state for debugging and monitoring

### After
- ✅ Inactive workers have clean state (`startTime: null`)
- ✅ Duration calculations only apply to active workers
- ✅ Consistent state: inactive always means startTime is null
- ✅ Clear data for health checks and status displays

## Relationship to #108

This fix complements the fix from issue #108:

- **#108**: Always SET `startTime` when **activating** worker
- **#113**: Always CLEAR `startTime` when **deactivating** worker

Together, these ensure `startTime` accurately reflects the current task duration:
- When task starts → `startTime` set to now
- When task ends → `startTime` cleared to null
- Session reuse → `startTime` reset for new task

## Testing

### Manual Verification
1. Complete a task → verify `startTime` is null in projects.json
2. Run health auto-fix → verify `startTime` cleared when worker deactivated
3. Check inactive workers → all should have `startTime: null`
4. Activate worker → `startTime` should be set to current time
5. Deactivate worker → `startTime` should be cleared

### Expected State
```json
{
  "dev": {
    "active": false,
    "issueId": null,
    "startTime": null,  // ✅ Clean state
    "tier": "medior"
  }
}
```

## Acceptance Criteria

- ✅ `startTime` is cleared when workers are deactivated
- ✅ Inactive workers have `startTime: null`
- ✅ Duration calculations work correctly
- ✅ Health check auto-fixes clear `startTime`
- ✅ Data consistency maintained

## Related

- Issue #108: Fixed startTime to reset on task assignment
- Issue #113: This fix - clear startTime on deactivation

As described in issue #113