### PR TITLE
fix: send Telegram notifications for heartbeat pickups (#139)

### DIFF
--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -18,6 +18,7 @@ import { log as auditLog } from "../audit.js";
 import { checkWorkerHealth } from "./health.js";
 import { projectTick } from "./tick.js";
 import { createProvider } from "../providers/index.js";
+import { notifyTickPickups, getNotificationConfig } from "../notify.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -254,6 +255,16 @@ export async function tick(opts: {
 
     result.totalPickups += tickResult.pickups.length;
     result.totalSkipped += tickResult.skipped.length;
+
+    // Notify project group about any pickups
+    if (tickResult.pickups.length > 0) {
+      const notifyConfig = getNotificationConfig(pluginConfig);
+      await notifyTickPickups(tickResult.pickups, {
+        workspaceDir,
+        config: notifyConfig,
+        channel: project.channel,
+      });
+    }
     if (isProjectActive || tickResult.pickups.length > 0) activeProjects++;
   }
 


### PR DESCRIPTION
Addresses issue #139

When the heartbeat service dispatches workers via `projectTick()`, it now calls `notifyTickPickups()` to send notifications to the project's Telegram group, matching the behavior of `work_finish`'s `tickAndNotify()` helper.

**Changes:**
- Import `notifyTickPickups` and `getNotificationConfig` from `notify.ts`
- After `projectTick()` returns pickups, call `notifyTickPickups()` with the workspace dir, notification config, and project channel