### PR TITLE
fix: change Planning label colour from blue to grey

### DIFF
--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -11,7 +11,7 @@ export const STATE_LABELS = [
 export type StateLabel = (typeof STATE_LABELS)[number];
 
 export const LABEL_COLORS: Record<StateLabel, string> = {
-  Planning: "#6699cc", "To Do": "#428bca", Doing: "#f0ad4e", "To Test": "#5bc0de",
+  Planning: "#95a5a6", "To Do": "#428bca", Doing: "#f0ad4e", "To Test": "#5bc0de",
   Testing: "#9b59b6", Done: "#5cb85c", "To Improve": "#d9534f", Refining: "#f39c12",
 };
 


### PR DESCRIPTION
Addresses issue #144

## Summary

Changes the Planning label colour from `#6699cc` (blue) to `#95a5a6` (grey/slate) to make it visually distinct from the To Do label (`#428bca`, also blue).

## Note

This only affects newly created labels. Existing repositories may need the label colour updated manually or via a migration.