### PR TITLE
feat: include issue comments in worker task context (#148)

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -65,6 +65,14 @@ export class GitHubProvider implements IssueProvider {
     return toIssue(JSON.parse(raw) as GhIssue);
   }
 
+  async listComments(issueId: number): Promise<import("./provider.js").IssueComment[]> {
+    try {
+      const raw = await this.gh(["api", `repos/:owner/:repo/issues/${issueId}/comments`, "--jq", ".[] | {author: .user.login, body: .body, created_at: .created_at}"]);
+      if (!raw) return [];
+      return raw.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    } catch { return []; }
+  }
+
   async transitionLabel(issueId: number, from: StateLabel, to: StateLabel): Promise<void> {
     const issue = await this.getIssue(issueId);
     const stateLabels = issue.labels.filter((l) => STATE_LABELS.includes(l as StateLabel));

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -24,12 +24,19 @@ export type Issue = {
   web_url: string;
 };
 
+export type IssueComment = {
+  author: string;
+  body: string;
+  created_at: string;
+};
+
 export interface IssueProvider {
   ensureLabel(name: string, color: string): Promise<void>;
   ensureAllStateLabels(): Promise<void>;
   createIssue(title: string, description: string, label: StateLabel, assignees?: string[]): Promise<Issue>;
   listIssuesByLabel(label: StateLabel): Promise<Issue[]>;
   getIssue(issueId: number): Promise<Issue>;
+  listComments(issueId: number): Promise<IssueComment[]>;
   transitionLabel(issueId: number, from: StateLabel, to: StateLabel): Promise<void>;
   closeIssue(issueId: number): Promise<void>;
   reopenIssue(issueId: number): Promise<void>;

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -117,7 +117,7 @@ export async function projectTick(opts: {
   /** Only attempt this role. Used by work_start to fill the other slot. */
   targetRole?: "dev" | "qa";
   /** Optional provider override (for testing). Uses createProvider if omitted. */
-  provider?: Pick<IssueProvider, "listIssuesByLabel" | "transitionLabel">;
+  provider?: Pick<IssueProvider, "listIssuesByLabel" | "transitionLabel" | "listComments">;
 }): Promise<TickResult> {
   const { workspaceDir, groupId, agentId, sessionKey, pluginConfig, dryRun, maxPickups, targetRole } = opts;
 
@@ -175,6 +175,7 @@ export async function projectTick(opts: {
           issueTitle: issue.title, issueDescription: issue.description ?? "", issueUrl: issue.web_url,
           role, level: selectedLevel, fromLabel: currentLabel, toLabel: targetLabel,
           transitionLabel: (id, from, to) => provider.transitionLabel(id, from as StateLabel, to as StateLabel),
+          provider: provider as IssueProvider,
           pluginConfig, sessionKey,
         });
         pickups.push({

--- a/lib/tools/work-start.ts
+++ b/lib/tools/work-start.ts
@@ -97,6 +97,7 @@ export function createWorkStartTool(api: OpenClawPluginApi) {
         issueTitle: issue.title, issueDescription: issue.description ?? "", issueUrl: issue.web_url,
         role, level: selectedLevel, fromLabel: currentLabel, toLabel: targetLabel,
         transitionLabel: (id, from, to) => provider.transitionLabel(id, from as StateLabel, to as StateLabel),
+        provider,
         pluginConfig, sessionKey: ctx.sessionKey,
       });
 


### PR DESCRIPTION
Addresses issue #148

Workers now receive issue comments as part of their task context, ensuring they see:
- QA review feedback from failed tests
- Clarifications added after issue creation
- Discussion threads and prior attempt notes
- Human input added during refinement

**Changes:**
- Added `IssueComment` type and `listComments(issueId)` to `IssueProvider` interface
- Implemented `listComments` for GitHub (via `gh api`) and GitLab (via `glab api`, filters out system notes)
- Updated `buildTaskMessage()` to accept and format comments (last 20, to avoid context bloat)
- Updated `dispatchTask()` to fetch comments before building task message
- Updated call sites in `work-start.ts` and `tick.ts` to pass provider

Comments are formatted with author, timestamp, and body under a "## Comments" section in the task message.