### PR TITLE
refactor: centralize notifications in core dispatch/completion functions (#150)

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -8,7 +8,6 @@
  * - workerComplete: Worker completed task (→ project group)
  */
 import { log as auditLog } from "./audit.js";
-import type { TickAction } from "./services/tick.js";
 import { runCommand } from "./run-command.js";
 
 /** Per-event-type toggle. All default to true — set to false to suppress. */
@@ -157,43 +156,6 @@ export async function notify(
   });
 
   return sendMessage(target, message, channel, opts.workspaceDir);
-}
-
-/**
- * Send workerStart notifications for each tick pickup.
- *
- * Called after projectTick() returns pickups — callers pass the array
- * so each dispatched task gets a visible start notification in the project group.
- */
-export async function notifyTickPickups(
-  pickups: TickAction[],
-  opts: {
-    workspaceDir: string;
-    config?: NotificationConfig;
-    channel?: string;
-  },
-): Promise<void> {
-  for (const pickup of pickups) {
-    await notify(
-      {
-        type: "workerStart",
-        project: pickup.project,
-        groupId: pickup.groupId,
-        issueId: pickup.issueId,
-        issueTitle: pickup.issueTitle,
-        issueUrl: pickup.issueUrl,
-        role: pickup.role,
-        level: pickup.level,
-        sessionAction: pickup.sessionAction,
-      },
-      {
-        workspaceDir: opts.workspaceDir,
-        config: opts.config,
-        groupId: pickup.groupId,
-        channel: opts.channel,
-      },
-    );
-  }
 }
 
 /**

--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -18,7 +18,6 @@ import { log as auditLog } from "../audit.js";
 import { checkWorkerHealth, fetchGatewaySessions, type SessionLookup } from "./health.js";
 import { projectTick } from "./tick.js";
 import { createProvider } from "../providers/index.js";
-import { notifyTickPickups, getNotificationConfig } from "../notify.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -281,15 +280,7 @@ export async function tick(opts: {
     result.totalPickups += tickResult.pickups.length;
     result.totalSkipped += tickResult.skipped.length;
 
-    // Notify project group about any pickups
-    if (tickResult.pickups.length > 0) {
-      const notifyConfig = getNotificationConfig(pluginConfig);
-      await notifyTickPickups(tickResult.pickups, {
-        workspaceDir,
-        config: notifyConfig,
-        channel: project.channel,
-      });
-    }
+    // Notifications now handled by dispatchTask
     if (isProjectActive || tickResult.pickups.length > 0) activeProjects++;
   }
 

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -176,7 +176,9 @@ export async function projectTick(opts: {
           role, level: selectedLevel, fromLabel: currentLabel, toLabel: targetLabel,
           transitionLabel: (id, from, to) => provider.transitionLabel(id, from as StateLabel, to as StateLabel),
           provider: provider as IssueProvider,
-          pluginConfig, sessionKey,
+          pluginConfig,
+          channel: fresh.channel,
+          sessionKey,
         });
         pickups.push({
           project: project.name, groupId, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url,

--- a/lib/tools/work-start.ts
+++ b/lib/tools/work-start.ts
@@ -12,7 +12,6 @@ import type { StateLabel } from "../providers/provider.js";
 import { selectLevel } from "../model-selector.js";
 import { getWorker } from "../projects.js";
 import { dispatchTask } from "../dispatch.js";
-import { notify, getNotificationConfig } from "../notify.js";
 import { findNextIssue, detectRoleFromLabel, detectLevelFromLabels } from "../services/tick.js";
 import { isDevLevel } from "../tiers.js";
 import { requireWorkspaceDir, resolveProject, resolveProvider, getPluginConfig } from "../tool-helpers.js";
@@ -98,15 +97,10 @@ export function createWorkStartTool(api: OpenClawPluginApi) {
         role, level: selectedLevel, fromLabel: currentLabel, toLabel: targetLabel,
         transitionLabel: (id, from, to) => provider.transitionLabel(id, from as StateLabel, to as StateLabel),
         provider,
-        pluginConfig, sessionKey: ctx.sessionKey,
+        pluginConfig,
+        channel: project.channel,
+        sessionKey: ctx.sessionKey,
       });
-
-      // Notify
-      const notifyConfig = getNotificationConfig(pluginConfig);
-      await notify(
-        { type: "workerStart", project: project.name, groupId, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url, role, level: dr.level, sessionAction: dr.sessionAction },
-        { workspaceDir, config: notifyConfig, groupId, channel: project.channel ?? "telegram" },
-      );
 
       // Auto-tick disabled per issue #125 - work_start should only pick up the explicitly requested issue
       // The heartbeat service fills parallel slots automatically


### PR DESCRIPTION
Addresses issue #150

Moved notifications into the core dispatch and completion functions so they fire automatically regardless of caller. This eliminates fragile duplication across work_start, tickAndNotify, and heartbeat.

**Changes:**
- **dispatch.ts**: Added `channel` and `pluginConfig` to `DispatchOpts`, added workerStart notification at end of `dispatchTask()`
- **pipeline.ts**: Added `projectName`, `channel`, `pluginConfig` to `executeCompletion()`, added workerComplete notification at end
- **work-start.ts**: Removed duplicate notify call (now handled by dispatchTask), pass channel to dispatchTask
- **work-finish.ts**: Removed duplicate notify call (now handled by executeCompletion), pass projectName/channel/pluginConfig to executeCompletion
- **tick.ts**: Pass channel to dispatchTask
- **tool-helpers.ts**: Removed notification logic from `tickAndNotify` (just runs tick now, notifications handled by dispatchTask)
- **heartbeat.ts**: Removed notifyTickPickups call (notifications now handled by dispatchTask)
- **notify.ts**: Removed `notifyTickPickups` function (no longer needed)

**Result:** Single responsibility — dispatch handles start notifications, completion handles finish notifications. No caller needs to remember to notify.