### PR TITLE
fix: blocked issues now go to Refining to prevent infinite dispatch loop (#142)

### DIFF
--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -22,17 +22,17 @@ export const COMPLETION_RULES: Record<string, CompletionRule> = {
   "qa:pass":     { from: "Testing", to: "Done",       closeIssue: true },
   "qa:fail":     { from: "Testing", to: "To Improve", reopenIssue: true },
   "qa:refine":   { from: "Testing", to: "Refining" },
-  "dev:blocked": { from: "Doing",   to: "To Do" },
-  "qa:blocked":  { from: "Testing", to: "To Test" },
+  "dev:blocked": { from: "Doing",   to: "Refining" },
+  "qa:blocked":  { from: "Testing", to: "Refining" },
 };
 
 export const NEXT_STATE: Record<string, string> = {
   "dev:done":    "QA queue",
-  "dev:blocked": "returned to queue",
+  "dev:blocked": "moved to Refining - needs human input",
   "qa:pass":     "Done!",
   "qa:fail":     "back to DEV",
   "qa:refine":   "awaiting human decision",
-  "qa:blocked":  "returned to QA queue",
+  "qa:blocked":  "moved to Refining - needs human input",
 };
 
 const EMOJI: Record<string, string> = {


### PR DESCRIPTION
Addresses issue #142

## Problem
When a worker returned `blocked`, the issue was sent back to the pickup queue ("To Do" for DEV, "To Test" for QA). The `work_finish` function then immediately called `tickAndNotify()`, which re-dispatched the same blocked issue, creating an infinite loop.

Observed on #137: the worker was dispatched **7 times in ~2 minutes**, burning tokens each attempt.

## Root Cause
- `dev:blocked` transitioned from "Doing" → "To Do" (back in DEV queue)
- `qa:blocked` transitioned from "Testing" → "To Test" (back in QA queue)
- Both "To Do" and "To Test" are in `DEV_LABELS` and `QA_LABELS` respectively
- `projectTick()` immediately found and re-dispatched the blocked issue

## Fix
Changed completion rules in `pipeline.ts`:
- `dev:blocked`: "Doing" → **"Refining"** (was "To Do")
- `qa:blocked`: "Testing" → **"Refining"** (was "To Test")

**"Refining" is NOT in the pickup labels**, so blocked issues will halt auto-dispatch until a human reviews and manually moves them back to the queue or closes them.

## Result
- Blocked issues require human intervention (as intended)
- No infinite loops
- Clear signal that an issue needs attention (Refining state)
- Consistent with `qa:refine` behavior