### PR TITLE
fix: dispatch timeout causing missed Telegram notifications

### DIFF
--- a/lib/tool-helpers.ts
+++ b/lib/tool-helpers.ts
@@ -4,7 +4,7 @@
  * Eliminates repeated boilerplate across tools: workspace validation,
  * project resolution, provider creation.
  */
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk";
 import type { ToolContext } from "./types.js";
 import { readProjects, getProject, type Project, type ProjectsData } from "./projects.js";
 import { createProvider, type ProviderWithType } from "./providers/index.js";
@@ -60,6 +60,8 @@ export async function tickAndNotify(opts: {
   pluginConfig?: Record<string, unknown>;
   sessionKey?: string;
   targetRole?: "dev" | "qa";
+  /** Plugin runtime for direct API access (avoids CLI subprocess timeouts) */
+  runtime?: PluginRuntime;
 }): Promise<TickAction[]> {
   try {
     const result = await projectTick({
@@ -69,6 +71,7 @@ export async function tickAndNotify(opts: {
       pluginConfig: opts.pluginConfig,
       sessionKey: opts.sessionKey,
       targetRole: opts.targetRole,
+      runtime: opts.runtime,
     });
     return result.pickups;
   } catch {

--- a/lib/tools/work-finish.ts
+++ b/lib/tools/work-finish.ts
@@ -59,12 +59,13 @@ export function createWorkFinishTool(api: OpenClawPluginApi) {
 
       const pluginConfig = getPluginConfig(api);
 
-      // Execute completion (pipeline service handles notification)
+      // Execute completion (pipeline service handles notification with runtime)
       const completion = await executeCompletion({
         workspaceDir, groupId, role, result, issueId, summary, prUrl, provider, repoPath,
         projectName: project.name,
         channel: project.channel,
         pluginConfig,
+        runtime: api.runtime,
       });
 
       const output: Record<string, unknown> = {
@@ -72,9 +73,10 @@ export function createWorkFinishTool(api: OpenClawPluginApi) {
         ...completion,
       };
 
-      // Tick: fill free slots (notifications handled by dispatchTask)
+      // Tick: fill free slots (notifications handled by dispatchTask with runtime)
       const tickPickups = await tickAndNotify({
         workspaceDir, groupId, agentId: ctx.agentId, pluginConfig, sessionKey: ctx.sessionKey,
+        runtime: api.runtime,
       });
       if (tickPickups.length) output.tickPickups = tickPickups;
 

--- a/lib/tools/work-start.ts
+++ b/lib/tools/work-start.ts
@@ -89,7 +89,7 @@ export function createWorkStartTool(api: OpenClawPluginApi) {
         }
       }
 
-      // Dispatch
+      // Dispatch (pass runtime for direct API access)
       const pluginConfig = getPluginConfig(api);
       const dr = await dispatchTask({
         workspaceDir, agentId: ctx.agentId, groupId, project, issueId: issue.iid,
@@ -100,6 +100,7 @@ export function createWorkStartTool(api: OpenClawPluginApi) {
         pluginConfig,
         channel: project.channel,
         sessionKey: ctx.sessionKey,
+        runtime: api.runtime,
       });
 
       // Auto-tick disabled per issue #125 - work_start should only pick up the explicitly requested issue


### PR DESCRIPTION
Addresses issue #153

## Problem

`dispatchTask()` shells out to `openclaw gateway call sessions.patch` which times out after 10s when the gateway is busy. This causes:
1. Notifications never fire (at end of dispatchTask, after the timeout)
2. Worker state may not be recorded in projects.json
3. Workers run silently (gateway processes the task)

## Root Cause

The heartbeat service runs inside the gateway process but communicates with it via CLI → subprocess → WebSocket RPC. The 10s gateway RPC timeout kills the call even though the operation succeeds.

## Solution (3 changes)

### 1. Make `ensureSession` fire-and-forget
Session key is deterministic (`agent:main:subagent:devclaw-dev-medior`). We don't need to wait for `sessions.patch` to confirm — just fire it and proceed. If it fails, health check catches orphaned state later.

### 2. Use runtime API for notifications instead of CLI
The plugin SDK exposes `api.runtime.channel.telegram.sendMessageTelegram()` directly. Use this in `notify.ts` instead of shelling out to `openclaw message send`, eliminating the CLI→WebSocket timeout for notifications.

### 3. Move notification before session dispatch
Fire `workerStart` notification right after label transition succeeds (before the session call that can timeout). Same for `workerComplete` — fire early in `executeCompletion()`.

## Threading the runtime API

Passed `runtime` through opts to `dispatchTask`, `executeCompletion`, `projectTick`, and `tickAndNotify`.

## Files Changed

- `lib/dispatch.ts` — fire-and-forget ensureSession, early notification, accept runtime
- `lib/notify.ts` — use runtime API for direct channel sends (Telegram, WhatsApp, Discord, Slack, Signal)
- `lib/services/pipeline.ts` — early notification, accept runtime
- `lib/services/tick.ts` — pass runtime through to dispatchTask
- `lib/tool-helpers.ts` — accept runtime in tickAndNotify
- `lib/tools/work-start.ts` — pass api.runtime to dispatchTask
- `lib/tools/work-finish.ts` — pass api.runtime to executeCompletion/tickAndNotify

## Testing

- [x] `npm run build` passes