### PR TITLE
fix: strengthen AGENTS.md to always include issue URLs in responses (#138)

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -117,6 +117,15 @@ You are a **development orchestrator** — a planner and dispatcher, not a coder
 - Running tests in the codebase
 - Debugging that requires code changes
 
+### Communication Guidelines
+
+**Always include issue URLs** in your responses when discussing tasks. Tool responses include an \`announcement\` field with properly formatted links — use these or extract the URL from the response.
+
+Examples:
+- ✅ "Created issue #42: Fix login bug 🔗 https://github.com/org/repo/issues/42"
+- ✅ "Picked up #42 for DEV (medior) 🔗 https://github.com/org/repo/issues/42"
+- ❌ "Created issue #42 about the login bug" (missing URL)
+
 ### DevClaw Tools
 
 All orchestration goes through these tools. You do NOT manually manage sessions, labels, or projects.json.
@@ -158,7 +167,7 @@ Evaluate each task and pass the appropriate developer level to \`work_start\`:
 2. Priority: \`To Improve\` (fix failures) > \`To Test\` (QA) > \`To Do\` (new work)
 3. Evaluate complexity, choose developer level
 4. Call \`work_start\` with \`issueId\`, \`role\`, \`projectGroupId\`, \`level\`
-5. Post the \`announcement\` from the tool response to Telegram
+5. **Always include the issue URL** in your response — copy it from \`announcement\` or the tool response
 
 ### When Work Completes
 
@@ -169,7 +178,7 @@ Workers call \`work_finish\` themselves — the label transition, state update, 
 - QA "pass" → Done, no further dispatch
 - QA "refine" / blocked → needs human input
 
-The response includes \`tickPickups\` showing any tasks that were auto-dispatched. Post announcements from the tool response to Telegram.
+The response includes \`tickPickups\` showing any tasks that were auto-dispatched. **Always include issue URLs** in your response — these are in the \`announcement\` fields.
 
 ### Prompt Instructions
 


### PR DESCRIPTION
Addresses issue #138

## Problem
The orchestrator sometimes omitted GitHub issue URLs from responses when creating or picking up tasks, even though tool responses include properly formatted `announcement` fields with links.

## Root Cause
The AGENTS.md template said "post the announcement" but didn't explicitly require including issue URLs or posting announcements verbatim. This left room for the LLM to summarize or paraphrase without the link.

## Fix
Strengthened the AGENTS.md template in `lib/templates.ts`:

1. **Added new "Communication Guidelines" section** with explicit requirement and examples:
   - ✅ "Created issue #42: Fix login bug 🔗 https://github.com/org/repo/issues/42"
   - ❌ "Created issue #42 about the login bug" (missing URL)

2. **Updated "Picking Up Work" section**: Changed "Post the `announcement` from the tool response" to **"Always include the issue URL"** with clear instruction to copy from announcement

3. **Updated "When Work Completes" section**: Changed "Post announcements from the tool response" to **"Always include issue URLs"** with note that they're in announcement fields

## Result
- Clear, explicit requirement that issue URLs must always be included
- Examples showing correct and incorrect behavior
- Applies to task creation, work pickup, and completion announcements
- Template will be used by new setups and can be applied to existing AGENTS.md files