### PR TITLE
fix: remove chained dispatch from work_finish - heartbeat only pickup path (#156)

### DIFF
--- a/lib/tool-helpers.ts
+++ b/lib/tool-helpers.ts
@@ -4,11 +4,10 @@
  * Eliminates repeated boilerplate across tools: workspace validation,
  * project resolution, provider creation.
  */
-import type { OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { ToolContext } from "./types.js";
 import { readProjects, getProject, type Project, type ProjectsData } from "./projects.js";
 import { createProvider, type ProviderWithType } from "./providers/index.js";
-import { projectTick, type TickAction } from "./services/tick.js";
 
 /**
  * Require workspaceDir from context or throw a clear error.
@@ -47,35 +46,4 @@ export async function resolveProvider(project: Project): Promise<ProviderWithTyp
  */
 export function getPluginConfig(api: OpenClawPluginApi): Record<string, unknown> | undefined {
   return api.pluginConfig as Record<string, unknown> | undefined;
-}
-
-/**
- * Run projectTick (non-fatal). Notifications are now handled by dispatchTask.
- * Returns the pickups array (empty on failure).
- */
-export async function tickAndNotify(opts: {
-  workspaceDir: string;
-  groupId: string;
-  agentId?: string;
-  pluginConfig?: Record<string, unknown>;
-  sessionKey?: string;
-  targetRole?: "dev" | "qa";
-  /** Plugin runtime for direct API access (avoids CLI subprocess timeouts) */
-  runtime?: PluginRuntime;
-}): Promise<TickAction[]> {
-  try {
-    const result = await projectTick({
-      workspaceDir: opts.workspaceDir,
-      groupId: opts.groupId,
-      agentId: opts.agentId,
-      pluginConfig: opts.pluginConfig,
-      sessionKey: opts.sessionKey,
-      targetRole: opts.targetRole,
-      runtime: opts.runtime,
-    });
-    return result.pickups;
-  } catch {
-    /* non-fatal: tick failure shouldn't break the caller */
-    return [];
-  }
 }

--- a/lib/tools/work-finish.ts
+++ b/lib/tools/work-finish.ts
@@ -10,7 +10,7 @@ import type { ToolContext } from "../types.js";
 import { getWorker, resolveRepoPath } from "../projects.js";
 import { executeCompletion, getRule, NEXT_STATE } from "../services/pipeline.js";
 import { log as auditLog } from "../audit.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider, getPluginConfig, tickAndNotify } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, getPluginConfig } from "../tool-helpers.js";
 
 export function createWorkFinishTool(api: OpenClawPluginApi) {
   return (ctx: ToolContext) => ({
@@ -73,18 +73,10 @@ export function createWorkFinishTool(api: OpenClawPluginApi) {
         ...completion,
       };
 
-      // Tick: fill free slots (notifications handled by dispatchTask with runtime)
-      const tickPickups = await tickAndNotify({
-        workspaceDir, groupId, agentId: ctx.agentId, pluginConfig, sessionKey: ctx.sessionKey,
-        runtime: api.runtime,
-      });
-      if (tickPickups.length) output.tickPickups = tickPickups;
-
       // Audit
       await auditLog(workspaceDir, "work_finish", {
         project: project.name, groupId, issue: issueId, role, result,
         summary: summary ?? null, labelTransition: completion.labelTransition,
-        tickPickups: tickPickups.length,
       });
 
       return jsonResult(output);


### PR DESCRIPTION
Addresses issue #156

## Problem
`work_finish` called `tickAndNotify()` immediately after completion, creating race conditions (e.g. blocked → To Do → instant re-dispatch before Refining label could land) and making the system harder to reason about.

## Root Cause
The chained dispatch pattern meant that:
- State transitions and re-dispatch happened atomically within the same `work_finish` call
- External state changes (via `task_update`) couldn't interrupt the pickup
- The same issue could be re-dispatched before label changes settled
- Multiple code paths for pickup made debugging difficult

## Solution
Removed all chained dispatch. **Heartbeat is now the only code path** that picks up queued work.

### Changes
1. **work-finish.ts**: Removed `tickAndNotify()` call after completion
2. **tool-helpers.ts**: Removed `tickAndNotify()` function entirely (no longer used)
3. Removed `tickPickups` from work_finish output and audit log

### Benefits
- **One code path for all pickups** (heartbeat only)
- **No race conditions** between state transitions and re-dispatch
- **Every pickup visible** in heartbeat tick logs
- **Blocked → Refining has time to settle** before next scan
- **Simpler code**, fewer moving parts

### Tradeoff
Up to 60s latency between DEV done → QA pickup (vs instant). This is acceptable and can be lowered by adjusting `work_heartbeat.intervalSeconds` in openclaw.json if needed.

## Testing
Demonstrated by issue #137 infinite loop - this fix prevents that pattern entirely.