### PR TITLE
chore: remove test comment from README.md (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,5 +470,3 @@ Full parameters and usage in the [Tools Reference](docs/TOOLS.md).
 ## License
 
 MIT
-
-<!-- devclaw test -->


### PR DESCRIPTION
As described in issue #167

Cleanup - removed the `<!-- devclaw test -->` comment that was added by test issue #163.