### PR TITLE
docs: remove outdated auto-tick references from work_finish (#159)

### DIFF
--- a/lib/tools/work-finish.ts
+++ b/lib/tools/work-finish.ts
@@ -1,8 +1,8 @@
 /**
  * work_finish — Complete a task (DEV done, QA pass/fail/refine/blocked).
  *
- * Delegates side-effects to pipeline service, then ticks the project queue
- * to fill free slots, sends notifications, and logs to audit.
+ * Delegates side-effects to pipeline service: label transition, state update,
+ * issue close/reopen, notifications, and audit logging.
  */
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { jsonResult } from "openclaw/plugin-sdk";
@@ -16,7 +16,7 @@ export function createWorkFinishTool(api: OpenClawPluginApi) {
   return (ctx: ToolContext) => ({
     name: "work_finish",
     label: "Work Finish",
-    description: `Complete a task: DEV done/blocked, QA pass/fail/refine/blocked. Handles label transition, state update, issue close/reopen, notifications, audit, and auto-ticks the queue to fill free slots.`,
+    description: `Complete a task: DEV done/blocked, QA pass/fail/refine/blocked. Handles label transition, state update, issue close/reopen, notifications, and audit logging.`,
     parameters: {
       type: "object",
       required: ["role", "result", "projectGroupId"],


### PR DESCRIPTION
As described in issue #159

## Problem
The work_finish tool had outdated documentation claiming it "auto-ticks the queue to fill free slots", but this functionality was removed in #156.

## Changes
Updated two places in `lib/tools/work-finish.ts`:

1. **Header comment** (lines 1-5):
   - Removed: "then ticks the project queue to fill free slots"
   - Added: clear description of actual behavior (label transition, state update, issue close/reopen, notifications, audit)

2. **Tool description** (line 19):
   - Removed: "audit, and auto-ticks the queue to fill free slots"
   - Changed to: "and audit logging"

## Result
Documentation now accurately reflects the current behavior: work_finish handles completion side-effects but does NOT auto-dispatch the next task. The heartbeat service (every 60s) is the only pickup path, as established in #156.