### PR TITLE
fix: refactor queue.ts to use workflow config instead of hardcoded labels

### DIFF
--- a/lib/tools/status.ts
+++ b/lib/tools/status.ts
@@ -9,8 +9,9 @@ import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../types.js";
 import { readProjects, getProject } from "../projects.js";
 import { log as auditLog } from "../audit.js";
-import { fetchProjectQueues, type QueueLabel } from "../services/queue.js";
+import { fetchProjectQueues, getTotalQueuedCount, getQueueLabelsWithPriority } from "../services/queue.js";
 import { requireWorkspaceDir, getPluginConfig } from "../tool-helpers.js";
+import { DEFAULT_WORKFLOW } from "../workflow.js";
 
 export function createStatusTool(api: OpenClawPluginApi) {
   return (ctx: ToolContext) => ({
@@ -31,6 +32,9 @@ export function createStatusTool(api: OpenClawPluginApi) {
       const pluginConfig = getPluginConfig(api);
       const projectExecution = (pluginConfig?.projectExecution as string) ?? "parallel";
 
+      // TODO: Load per-project workflow when supported
+      const workflow = DEFAULT_WORKFLOW;
+
       const data = await readProjects(workspaceDir);
       const projectIds = groupId ? [groupId] : Object.keys(data.projects);
 
@@ -40,30 +44,59 @@ export function createStatusTool(api: OpenClawPluginApi) {
           const project = getProject(data, pid);
           if (!project) return null;
 
-          const queues = await fetchProjectQueues(project);
-          const count = (label: QueueLabel) => queues[label].length;
+          const queues = await fetchProjectQueues(project, workflow);
+
+          // Build dynamic queue object with counts
+          const queueCounts: Record<string, number> = {};
+          for (const [label, issues] of Object.entries(queues)) {
+            queueCounts[label] = issues.length;
+          }
 
           return {
             name: project.name,
             groupId: pid,
             roleExecution: project.roleExecution ?? "parallel",
-            dev: { active: project.dev.active, issueId: project.dev.issueId, level: project.dev.level, startTime: project.dev.startTime },
-            qa: { active: project.qa.active, issueId: project.qa.issueId, level: project.qa.level, startTime: project.qa.startTime },
-            queue: { toImprove: count("To Improve"), toTest: count("To Test"), toDo: count("To Do") },
+            dev: {
+              active: project.dev.active,
+              issueId: project.dev.issueId,
+              level: project.dev.level,
+              startTime: project.dev.startTime,
+            },
+            qa: {
+              active: project.qa.active,
+              issueId: project.qa.issueId,
+              level: project.qa.level,
+              startTime: project.qa.startTime,
+            },
+            queue: queueCounts,
           };
         }),
       );
 
-      const filtered = projects.filter(Boolean);
+      const filtered = projects.filter(Boolean) as NonNullable<typeof projects[number]>[];
+
+      // Calculate total queued across all projects
+      const totalQueued = filtered.reduce(
+        (sum, p) => sum + Object.values(p.queue).reduce((s, c) => s + c, 0),
+        0,
+      );
 
       await auditLog(workspaceDir, "status", {
         projectCount: filtered.length,
-        totalQueued: filtered.reduce((s, p) => s + p!.queue.toImprove + p!.queue.toTest + p!.queue.toDo, 0),
+        totalQueued,
       });
+
+      // Include queue labels in response for context
+      const queueLabels = getQueueLabelsWithPriority(workflow).map((q) => ({
+        label: q.label,
+        role: q.role,
+        priority: q.priority,
+      }));
 
       return jsonResult({
         success: true,
         execution: { projectExecution },
+        queueLabels,
         projects: filtered,
       });
     },


### PR DESCRIPTION
Addresses issue #162

## Problem

`lib/services/queue.ts` was not updated during the workflow refactor (#147) and still contained hardcoded queue labels:

```typescript
export type QueueLabel = "To Improve" | "To Test" | "To Do";
export const QUEUE_PRIORITY: Record<QueueLabel, number> = { ... };
```

## Solution

Refactored to use workflow config for all queue operations:

- **`getQueueLabelsWithPriority(workflow)`** — derive queue labels with priorities from workflow states
- **`getQueuePriority(label, workflow)`** — get priority for any queue label
- **`getTaskPriority(label, issue, workflow)`** — updated to use workflow
- **`getRoleForLabel(label, workflow)`** — updated to use workflow
- **`fetchProjectQueues(project, workflow)`** — now fetches all workflow-defined queues
- **`getTotalQueuedCount(queues)`** — new helper for totaling queued issues

## status.ts Updates

- Uses dynamic queue labels from workflow
- Returns `queueLabels` array in response showing configured queues
- Queue counts object uses actual label names instead of hardcoded keys

## Backward Compatibility

- `QueueLabel` type kept as deprecated alias
- `QUEUE_PRIORITY` constant kept as deprecated
- All functions accept optional workflow parameter, default to `DEFAULT_WORKFLOW`

## Testing

- [x] `npm run build` passes