### PR TITLE
fix: update heartbeat.ts type signatures to accept SessionLookup | null

### DIFF
--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -224,7 +224,7 @@ export async function tick(opts: {
   agentId?: string;
   config: HeartbeatConfig;
   pluginConfig?: Record<string, unknown>;
-  sessions: SessionLookup;
+  sessions: SessionLookup | null;
   logger: { info(msg: string): void; warn(msg: string): void };
 }): Promise<TickResult> {
   const { workspaceDir, agentId, config, pluginConfig, sessions } = opts;
@@ -301,7 +301,7 @@ async function performHealthPass(
   workspaceDir: string,
   groupId: string,
   project: any,
-  sessions: SessionLookup,
+  sessions: SessionLookup | null,
 ): Promise<number> {
   const { provider } = await createProvider({ repo: project.repo });
   let fixedCount = 0;


### PR DESCRIPTION
As described in issue #169

## Changes
- Updated `tick()` function: `sessions` parameter now accepts `SessionLookup | null`
- Updated `performHealthPass()` function: `sessions` parameter now accepts `SessionLookup | null`

## Context
Following issue #165, `fetchGatewaySessions()` now returns `SessionLookup | null` to distinguish between "no sessions" and "gateway unavailable". This PR updates the type signatures in heartbeat.ts to match the updated health.ts signatures.

## Testing
- ✅ TypeScript compilation passes
- ✅ Type consistency between health.ts and heartbeat.ts

## Related
- #165 - Health check gateway timeout fix (parent issue)