### PR TITLE
docs: remove outdated scheduler tick references from AGENTS.md template

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -138,7 +138,7 @@ All orchestration goes through these tools. You do NOT manually manage sessions,
 | \`status\` | Task queue and worker state per project (lightweight dashboard) |
 | \`health\` | Scan worker health: zombies, stale workers, orphaned state. Pass fix=true to auto-fix |
 | \`work_start\` | End-to-end: label transition, level assignment, session create/reuse, dispatch with role instructions |
-| \`work_finish\` | End-to-end: label transition, state update, issue close/reopen. Ticks scheduler after completion. |
+| \`work_finish\` | End-to-end: label transition, state update, issue close/reopen |
 
 ### Pipeline Flow
 
@@ -171,14 +171,14 @@ Evaluate each task and pass the appropriate developer level to \`work_start\`:
 
 ### When Work Completes
 
-Workers call \`work_finish\` themselves — the label transition, state update, and audit log happen atomically. After completion, \`work_finish\` ticks the scheduler to fill free slots:
+Workers call \`work_finish\` themselves — the label transition, state update, and audit log happen atomically. The heartbeat service will pick up the next task on its next cycle:
 
 - DEV "done" → issue moves to "To Test" → scheduler dispatches QA
 - QA "fail" → issue moves to "To Improve" → scheduler dispatches DEV
 - QA "pass" → Done, no further dispatch
 - QA "refine" / blocked → needs human input
 
-The response includes \`tickPickups\` showing any tasks that were auto-dispatched. **Always include issue URLs** in your response — these are in the \`announcement\` fields.
+**Always include issue URLs** in your response — these are in the \`announcement\` fields.
 
 ### Prompt Instructions
 


### PR DESCRIPTION
As described in issue #177

## Changes

Updated `lib/templates.ts` (AGENTS.md template) to remove all outdated references to work_finish triggering the scheduler:

1. **Line 141** (DevClaw Tools table): Removed "Ticks scheduler after completion" from work_finish description
2. **Line 174** (When Work Completes section): Changed from "work_finish ticks the scheduler to fill free slots" to "heartbeat service will pick up the next task on its next cycle"
3. **Line 182**: Removed reference to "tickPickups showing any tasks that were auto-dispatched"

## Context

Issue #177 identified line 141 as the last remaining reference to work_finish ticking the scheduler. During implementation, discovered that lines 174 and 182 also contained outdated references that should have been fixed in #174 but were missed because that PR only updated the workspace AGENTS.md file directly, not the template in lib/templates.ts.

## Impact

Fixes documentation inconsistencies. The AGENTS.md template now correctly reflects that:
- The heartbeat service handles all queue pickup operations
- work_finish does NOT trigger immediate dispatch
- This aligns with the changes from #156

## Related Issues

- #177 - Update AGENTS.md line 86 (this issue)
- #174 - Update AGENTS.md and README.md (covered workspace file but not template)
- #156 - Remove chained dispatch (where functionality was removed)