### PR TITLE
fix: Persist issue tracker provider type (#193)

### DIFF
--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -22,6 +22,8 @@ export type Project = {
   deployBranch: string;
   /** Messaging channel for this project's group (e.g. "telegram", "whatsapp", "discord", "slack"). Stored at registration time. */
   channel?: string;
+  /** Issue tracker provider type (github or gitlab). Auto-detected at registration, stored for reuse. */
+  provider?: "github" | "gitlab";
   /** Project-level role execution: parallel (DEV+QA can run simultaneously) or sequential (only one role at a time). Default: parallel */
   roleExecution?: "parallel" | "sequential";
   maxDevWorkers?: number;

--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -304,7 +304,7 @@ async function performHealthPass(
   project: any,
   sessions: SessionLookup | null,
 ): Promise<number> {
-  const { provider } = await createProvider({ repo: project.repo });
+  const { provider } = await createProvider({ repo: project.repo, provider: project.provider });
   let fixedCount = 0;
 
   for (const role of getAllRoleIds()) {

--- a/lib/services/queue.ts
+++ b/lib/services/queue.ts
@@ -110,7 +110,7 @@ export async function fetchProjectQueues(
   project: Project,
   workflow: WorkflowConfig = DEFAULT_WORKFLOW,
 ): Promise<Record<string, Issue[]>> {
-  const { provider } = await createProvider({ repo: project.repo });
+  const { provider } = await createProvider({ repo: project.repo, provider: project.provider });
   const queueLabels = getQueueLabelsWithPriority(workflow);
   const queues: Record<string, Issue[]> = {};
 

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -162,7 +162,7 @@ export async function projectTick(opts: {
   const project = (await readProjects(workspaceDir)).projects[groupId];
   if (!project) return { pickups: [], skipped: [{ reason: `Project not found: ${groupId}` }] };
 
-  const provider = opts.provider ?? (await createProvider({ repo: project.repo })).provider;
+  const provider = opts.provider ?? (await createProvider({ repo: project.repo, provider: project.provider })).provider;
   const roleExecution = project.roleExecution ?? "parallel";
   const roles: Role[] = targetRole ? [targetRole] : getAllRoleIds() as Role[];
 

--- a/lib/tool-helpers.ts
+++ b/lib/tool-helpers.ts
@@ -36,9 +36,10 @@ export async function resolveProject(
 
 /**
  * Create an issue provider for a project.
+ * Uses stored provider type from project config if available, otherwise auto-detects.
  */
 export async function resolveProvider(project: Project): Promise<ProviderWithType> {
-  return createProvider({ repo: project.repo });
+  return createProvider({ repo: project.repo, provider: project.provider });
 }
 
 /**

--- a/lib/tools/project-register.ts
+++ b/lib/tools/project-register.ts
@@ -161,6 +161,7 @@ export function createProjectRegisterTool() {
         baseBranch,
         deployBranch,
         channel,
+        provider: providerType,
         roleExecution,
         dev: emptyWorkerState([...getLevelsForRole("dev")]),
         qa: emptyWorkerState([...getLevelsForRole("qa")]),


### PR DESCRIPTION
## Problem

Issue tracker source configuration (GitHub/GitLab) was being auto-detected on every `createProvider()` call but never persisted to `projects.json`. This caused loss of configuration after session restart.

## Solution

- Added `provider` field to `Project" type definition
- Store detected provider type during project registration
- Pass stored provider type to all `createProvider()` calls
- Falls back to auto-detection if not present (backward compatibility)

## Changes

1. **lib/projects.ts**: Add optional `provider?: 'github' | 'gitlab'` field to `Project` type
2. **lib/tools/project-register.ts**: Save `providerType` to projects.json during registration
3. **lib/tool-helpers.ts**: Pass `project.provider` to `createProvider()`
4. **lib/services/heartbeat.ts**: Pass `project.provider` to `createProvider()`
5. **lib/services/queue.ts**: Pass `project.provider` to `createProvider()`
6. **lib/services/tick.ts**: Pass `project.provider` to `createProvider()`

## Testing

✅ Verified TypeScript type consistency
✅ Confirmed backward compatibility (auto-detection fallback)
✅ All provider resolution paths updated

## Migration

Existing projects without `provider` field will auto-detect on next use. For best results, projects should be re-registered or manually edited to add the `provider` field.

Fixes #193