### PR TITLE
feat: add task_edit_body tool for initial-state issue corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ DevClaw gives the orchestrator 11 tools. These aren't just convenience wrappers 
 | `task_create` | Create a new issue (used by workers to file bugs they discover) |
 | `task_update` | Manually change an issue's state label |
 | `task_comment` | Add a comment to an issue (with role attribution) |
+| `task_edit_body` | Edit issue title/description (initial state only; audit-logged) |
 | `status` | Dashboard: queue counts + who's working on what |
 | `health` | Detect zombie workers, stale sessions, state inconsistencies |
 | `work_heartbeat` | Manually trigger a health check + queue dispatch cycle |

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import { createWorkFinishTool } from "./lib/tools/work-finish.js";
 import { createTaskCreateTool } from "./lib/tools/task-create.js";
 import { createTaskUpdateTool } from "./lib/tools/task-update.js";
 import { createTaskCommentTool } from "./lib/tools/task-comment.js";
+import { createTaskEditBodyTool } from "./lib/tools/task-edit-body.js";
 import { createStatusTool } from "./lib/tools/status.js";
 import { createHealthTool } from "./lib/tools/health.js";
 import { createProjectRegisterTool } from "./lib/tools/project-register.js";
@@ -76,6 +77,7 @@ const plugin = {
     api.registerTool(createTaskCreateTool(api), { names: ["task_create"] });
     api.registerTool(createTaskUpdateTool(api), { names: ["task_update"] });
     api.registerTool(createTaskCommentTool(api), { names: ["task_comment"] });
+    api.registerTool(createTaskEditBodyTool(api), { names: ["task_edit_body"] });
 
     // Architect
     api.registerTool(createResearchTaskTool(api), { names: ["research_task"] });

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -200,6 +200,14 @@ export class GitHubProvider implements IssueProvider {
     await this.gh(["issue", "comment", String(issueId), "--body", body]);
   }
 
+  async editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue> {
+    const args = ["issue", "edit", String(issueId)];
+    if (updates.title !== undefined) args.push("--title", updates.title);
+    if (updates.body !== undefined) args.push("--body", updates.body);
+    await this.gh(args);
+    return this.getIssue(issueId);
+  }
+
   async healthCheck(): Promise<boolean> {
     try { await this.gh(["auth", "status"]); return true; } catch { return false; }
   }

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -204,6 +204,14 @@ export class GitLabProvider implements IssueProvider {
     await this.glab(["issue", "note", String(issueId), "--message", body]);
   }
 
+  async editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue> {
+    const args = ["issue", "update", String(issueId)];
+    if (updates.title !== undefined) args.push("--title", updates.title);
+    if (updates.body !== undefined) args.push("--description", updates.body);
+    await this.glab(args);
+    return this.getIssue(issueId);
+  }
+
   async healthCheck(): Promise<boolean> {
     try { await this.glab(["auth", "status"]); return true; } catch { return false; }
   }

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -70,5 +70,6 @@ export interface IssueProvider {
   mergePr(issueId: number): Promise<void>;
   getPrDiff(issueId: number): Promise<string | null>;
   addComment(issueId: number, body: string): Promise<void>;
+  editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue>;
   healthCheck(): Promise<boolean>;
 }

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -47,6 +47,7 @@ export type ProviderCall =
   | { method: "mergePr"; args: { issueId: number } }
   | { method: "getPrDiff"; args: { issueId: number } }
   | { method: "addComment"; args: { issueId: number; body: string } }
+  | { method: "editIssue"; args: { issueId: number; updates: { title?: string; body?: string } } }
   | { method: "healthCheck"; args: {} };
 
 // ---------------------------------------------------------------------------
@@ -277,6 +278,15 @@ export class TestProvider implements IssueProvider {
       created_at: new Date().toISOString(),
     });
     this.comments.set(issueId, existing);
+  }
+
+  async editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue> {
+    this.calls.push({ method: "editIssue", args: { issueId, updates } });
+    const issue = this.issues.get(issueId);
+    if (!issue) throw new Error(`Issue #${issueId} not found in TestProvider`);
+    if (updates.title !== undefined) issue.title = updates.title;
+    if (updates.body !== undefined) issue.description = updates.body;
+    return issue;
   }
 
   async healthCheck(): Promise<boolean> {

--- a/lib/tools/task-edit-body.test.ts
+++ b/lib/tools/task-edit-body.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for task_edit_body tool — initial-state enforcement, change detection,
+ * and workflow integration.
+ *
+ * Run with: npx tsx --test lib/tools/task-edit-body.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { DEFAULT_WORKFLOW, getInitialStateLabel } from "../workflow.js";
+
+// ---------------------------------------------------------------------------
+// getInitialStateLabel
+// ---------------------------------------------------------------------------
+
+describe("getInitialStateLabel", () => {
+  it("should return 'Planning' for the default workflow", () => {
+    assert.strictEqual(getInitialStateLabel(DEFAULT_WORKFLOW), "Planning");
+  });
+
+  it("should return the correct label for a custom workflow", () => {
+    const custom = {
+      initial: "backlog",
+      states: {
+        backlog: { type: "hold" as const, label: "Backlog", color: "#aaa" },
+        inProgress: { type: "active" as const, label: "In Progress", color: "#bbb" },
+      },
+    };
+    assert.strictEqual(getInitialStateLabel(custom as any), "Backlog");
+  });
+
+  it("should NOT return a non-initial state", () => {
+    const label = getInitialStateLabel(DEFAULT_WORKFLOW);
+    assert.notStrictEqual(label, "To Do");
+    assert.notStrictEqual(label, "Doing");
+    assert.notStrictEqual(label, "Done");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task edit body — change detection logic (unit tests without provider)
+// ---------------------------------------------------------------------------
+
+describe("task_edit_body change detection", () => {
+  /**
+   * Simulate the change-detection logic from task_edit_body.ts
+   */
+  function detectChanges(
+    issue: { title: string; description: string },
+    updates: { title?: string; body?: string },
+  ): Record<string, { from: string; to: string }> {
+    const changes: Record<string, { from: string; to: string }> = {};
+    if (updates.title !== undefined && updates.title !== issue.title) {
+      changes.title = { from: issue.title, to: updates.title };
+    }
+    if (updates.body !== undefined && updates.body !== issue.description) {
+      changes.body = { from: issue.description, to: updates.body };
+    }
+    return changes;
+  }
+
+  it("should detect title change", () => {
+    const changes = detectChanges(
+      { title: "Old title", description: "desc" },
+      { title: "New title" },
+    );
+    assert.deepStrictEqual(Object.keys(changes), ["title"]);
+    assert.strictEqual(changes.title.from, "Old title");
+    assert.strictEqual(changes.title.to, "New title");
+  });
+
+  it("should detect body change", () => {
+    const changes = detectChanges(
+      { title: "title", description: "old body" },
+      { body: "new body" },
+    );
+    assert.deepStrictEqual(Object.keys(changes), ["body"]);
+    assert.strictEqual(changes.body.from, "old body");
+    assert.strictEqual(changes.body.to, "new body");
+  });
+
+  it("should detect both title and body change", () => {
+    const changes = detectChanges(
+      { title: "old title", description: "old body" },
+      { title: "new title", body: "new body" },
+    );
+    assert.deepStrictEqual(Object.keys(changes).sort(), ["body", "title"]);
+  });
+
+  it("should detect no change when title is unchanged", () => {
+    const changes = detectChanges(
+      { title: "same title", description: "desc" },
+      { title: "same title" },
+    );
+    assert.deepStrictEqual(changes, {});
+  });
+
+  it("should detect no change when body is unchanged", () => {
+    const changes = detectChanges(
+      { title: "title", description: "same body" },
+      { body: "same body" },
+    );
+    assert.deepStrictEqual(changes, {});
+  });
+
+  it("should ignore undefined updates", () => {
+    const changes = detectChanges(
+      { title: "title", description: "desc" },
+      {},
+    );
+    assert.deepStrictEqual(changes, {});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Initial state enforcement logic
+// ---------------------------------------------------------------------------
+
+describe("initial state enforcement", () => {
+  function checkInitialState(
+    currentState: string | null,
+    initialStateLabel: string,
+  ): { allowed: boolean; error?: string } {
+    if (currentState !== initialStateLabel) {
+      return {
+        allowed: false,
+        error: `Cannot edit: issue is in "${currentState ?? "unknown"}", ` +
+          `edits only allowed in "${initialStateLabel}".`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  it("should allow edits in initial state", () => {
+    const result = checkInitialState("Planning", "Planning");
+    assert.strictEqual(result.allowed, true);
+  });
+
+  it("should deny edits in non-initial state", () => {
+    const result = checkInitialState("Doing", "Planning");
+    assert.strictEqual(result.allowed, false);
+    assert.ok(result.error?.includes("Doing"));
+    assert.ok(result.error?.includes("Planning"));
+  });
+
+  it("should deny edits in Done state", () => {
+    const result = checkInitialState("Done", "Planning");
+    assert.strictEqual(result.allowed, false);
+  });
+
+  it("should deny edits when state is null", () => {
+    const result = checkInitialState(null, "Planning");
+    assert.strictEqual(result.allowed, false);
+    assert.ok(result.error?.includes("unknown"));
+  });
+
+  it("should work with custom initial state labels", () => {
+    const result = checkInitialState("Backlog", "Backlog");
+    assert.strictEqual(result.allowed, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audit comment body format
+// ---------------------------------------------------------------------------
+
+describe("auto-comment format", () => {
+  function buildComment(opts: {
+    changes: string[];
+    reason?: string;
+  }): string {
+    const timestamp = "2026-02-17T01:30:00.000Z";
+    const changeLines = opts.changes.map((c) => `- **${c === "title" ? "Title" : "Description"}** updated`);
+    return [
+      `📝 **Issue updated** at ${timestamp}`,
+      ...changeLines,
+      ...(opts.reason ? [`- **Reason:** ${opts.reason}`] : []),
+    ].join("\n");
+  }
+
+  it("should include timestamp in comment", () => {
+    const comment = buildComment({ changes: ["title"] });
+    assert.ok(comment.includes("2026-02-17"), "should include date");
+    assert.ok(comment.includes("📝"), "should include emoji");
+  });
+
+  it("should list title change", () => {
+    const comment = buildComment({ changes: ["title"] });
+    assert.ok(comment.includes("**Title** updated"));
+  });
+
+  it("should list body change", () => {
+    const comment = buildComment({ changes: ["body"] });
+    assert.ok(comment.includes("**Description** updated"));
+  });
+
+  it("should include reason when provided", () => {
+    const comment = buildComment({ changes: ["title"], reason: "Fixed typo" });
+    assert.ok(comment.includes("Fixed typo"));
+    assert.ok(comment.includes("**Reason:**"));
+  });
+
+  it("should omit reason line when not provided", () => {
+    const comment = buildComment({ changes: ["title"] });
+    assert.ok(!comment.includes("**Reason:**"));
+  });
+});

--- a/lib/tools/task-edit-body.ts
+++ b/lib/tools/task-edit-body.ts
@@ -1,0 +1,179 @@
+/**
+ * task_edit_body — Update issue title and/or description in the initial workflow state.
+ *
+ * Only allowed when the issue is in the first state of the workflow (e.g. "Planning").
+ * This prevents inadvertent edits to issues that are already in-progress.
+ *
+ * Provider (GitHub/GitLab) tracks revision history natively.
+ * DevClaw adds an explicit audit entry with who, when, and what changed.
+ * Optionally posts an auto-comment on the issue for traceability.
+ */
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult } from "openclaw/plugin-sdk";
+import type { ToolContext } from "../types.js";
+import { log as auditLog } from "../audit.js";
+import { loadConfig } from "../config/index.js";
+import { getInitialStateLabel } from "../workflow.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider } from "../tool-helpers.js";
+
+export function createTaskEditBodyTool(_api: OpenClawPluginApi) {
+  return (ctx: ToolContext) => ({
+    name: "task_edit_body",
+    label: "Task Edit Body",
+    description: `Update issue title and/or description. Only allowed in the initial workflow state (e.g. "Planning") — prevents editing in-progress work.
+
+Logs the edit to the audit trail with timestamp, caller, and a diff summary.
+Optionally posts an auto-comment on the issue for traceability.
+
+Examples:
+- Fix typo: { projectGroupId: "-123456789", issueId: 42, title: "Fix login timeout bug" }
+- Clarify scope: { projectGroupId: "-123456789", issueId: 42, body: "Updated requirements...", reason: "Clarified after meeting" }
+- Silent edit: { projectGroupId: "-123456789", issueId: 42, body: "...", addComment: false }`,
+    parameters: {
+      type: "object",
+      required: ["projectGroupId", "issueId"],
+      properties: {
+        projectGroupId: {
+          type: "string",
+          description: "Telegram/WhatsApp group ID (key in projects.json)",
+        },
+        issueId: {
+          type: "number",
+          description: "Issue ID to edit",
+        },
+        title: {
+          type: "string",
+          description: "New title for the issue (optional)",
+        },
+        body: {
+          type: "string",
+          description: "New body/description for the issue (optional)",
+        },
+        reason: {
+          type: "string",
+          description: "Why the edit was made (optional, for audit trail)",
+        },
+        addComment: {
+          type: "boolean",
+          description: "Post an auto-comment on the issue noting the edit (default: true)",
+        },
+      },
+    },
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const groupId = params.projectGroupId as string;
+      const issueId = params.issueId as number;
+      const newTitle = (params.title as string | undefined);
+      const newBody = (params.body as string | undefined);
+      const reason = (params.reason as string | undefined);
+      const addComment = (params.addComment as boolean | undefined) ?? true;
+      const workspaceDir = requireWorkspaceDir(ctx);
+
+      if (!newTitle && !newBody) {
+        throw new Error("At least one of 'title' or 'body' must be provided.");
+      }
+
+      const { project } = await resolveProject(workspaceDir, groupId);
+      const { provider, type: providerType } = await resolveProvider(project);
+
+      // Determine initial state from per-project workflow config
+      const resolvedConfig = await loadConfig(workspaceDir, project.name);
+      const initialStateLabel = getInitialStateLabel(resolvedConfig.workflow);
+
+      // Fetch current issue
+      const issue = await provider.getIssue(issueId);
+      const currentState = provider.getCurrentStateLabel(issue);
+
+      // Enforce initial-state-only constraint
+      if (currentState !== initialStateLabel) {
+        throw new Error(
+          `Cannot edit issue #${issueId}: it is in "${currentState ?? "unknown"}", ` +
+          `but edits are only allowed in the initial state "${initialStateLabel}". ` +
+          `Move it back to "${initialStateLabel}" first, or add a comment instead.`,
+        );
+      }
+
+      // Track what changes we're making
+      const changes: Record<string, { from: string; to: string }> = {};
+      if (newTitle !== undefined && newTitle !== issue.title) {
+        changes.title = { from: issue.title, to: newTitle };
+      }
+      if (newBody !== undefined && newBody !== issue.description) {
+        changes.body = { from: issue.description, to: newBody };
+      }
+
+      // Nothing actually changed
+      if (Object.keys(changes).length === 0) {
+        return jsonResult({
+          success: true,
+          issueId,
+          issueUrl: issue.web_url,
+          project: project.name,
+          changed: false,
+          announcement: `Issue #${issueId} already has the requested content — no changes made.\n🔗 ${issue.web_url}`,
+        });
+      }
+
+      // Apply the edit
+      const updatedIssue = await provider.editIssue(issueId, {
+        ...(newTitle !== undefined ? { title: newTitle } : {}),
+        ...(newBody !== undefined ? { body: newBody } : {}),
+      });
+
+      // Post auto-comment for traceability (best-effort — must not abort on failure)
+      if (addComment) {
+        const timestamp = new Date().toISOString();
+        const changeLines: string[] = [];
+        if (changes.title) {
+          changeLines.push(`- **Title** updated`);
+        }
+        if (changes.body) {
+          changeLines.push(`- **Description** updated`);
+        }
+        const commentBody = [
+          `📝 **Issue updated** at ${timestamp}`,
+          ...changeLines,
+          ...(reason ? [`- **Reason:** ${reason}`] : []),
+        ].join("\n");
+
+        provider.addComment(issueId, commentBody).catch((err) => {
+          auditLog(workspaceDir, "task_edit_body_warning", {
+            step: "addComment", issueId, error: (err as Error).message ?? String(err),
+          }).catch(() => {});
+        });
+      }
+
+      // Audit log
+      await auditLog(workspaceDir, "task_edit_body", {
+        project: project.name,
+        groupId,
+        issueId,
+        issueUrl: updatedIssue.web_url,
+        provider: providerType,
+        changes: Object.fromEntries(
+          Object.entries(changes).map(([k, v]) => [k, { from: v.from.slice(0, 200), to: v.to.slice(0, 200) }]),
+        ),
+        reason: reason ?? null,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Build change summary for announcement
+      const changedFields = Object.keys(changes).join(" and ");
+      let announcement = `✏️ Updated ${changedFields} of #${issueId}: "${updatedIssue.title}"`;
+      if (reason) announcement += ` — ${reason}`;
+      announcement += `\n🔗 ${updatedIssue.web_url}`;
+
+      return jsonResult({
+        success: true,
+        issueId,
+        issueTitle: updatedIssue.title,
+        issueUrl: updatedIssue.web_url,
+        project: project.name,
+        provider: providerType,
+        changed: true,
+        changes: Object.keys(changes),
+        announcement,
+      });
+    },
+  });
+}

--- a/lib/workflow.ts
+++ b/lib/workflow.ts
@@ -233,6 +233,14 @@ export function getStateLabels(workflow: WorkflowConfig): string[] {
 }
 
 /**
+ * Get the initial state label (the first state in the workflow, e.g. "Planning").
+ * Used by task_edit_body to enforce edits only in the initial state.
+ */
+export function getInitialStateLabel(workflow: WorkflowConfig): string {
+  return workflow.states[workflow.initial].label;
+}
+
+/**
  * Get label → color mapping.
  */
 export function getLabelColors(workflow: WorkflowConfig): Record<string, string> {


### PR DESCRIPTION
## Summary

Adds `task_edit_body` — a new tool to edit issue title and/or description, **only when the issue is in the initial workflow state** (e.g. `Planning`). Prevents accidental edits to in-progress work.

## What's New

**`task_edit_body({ projectGroupId, issueId, title?, body?, reason?, addComment? })`**

- ✅ Only allows edits in the first workflow state (derived per-project, not hardcoded to 'Planning')
- ✅ Skips silently when nothing actually changed (no-op detection)
- ✅ Audit-logged with project, issueId, changed fields (truncated from/to), reason, timestamp
- ✅ Optionally posts auto-comment on the issue for traceability (default: true)
- ✅ Clear error when issue is not in initial state

## Files Changed

| File | Change |
|------|--------|
| `providers/provider.ts` | New `editIssue(id, { title?, body? })` on IssueProvider interface |
| `providers/github.ts` | Implements via `gh issue edit --title --body` |
| `providers/gitlab.ts` | Implements via `glab issue update --title --description` |
| `workflow.ts` | New `getInitialStateLabel(workflow)` helper |
| `tools/task-edit-body.ts` | New tool (full implementation) |
| `testing/test-provider.ts` | `editIssue` added to TestProvider + ProviderCall union |
| `tools/task-edit-body.test.ts` | 19 unit tests |
| `README.md` | Tool reference table updated |

All 107 tests pass. TypeScript compiles clean.

Addresses issue #204