### PR TITLE
fix: heartbeat only auto-merges PRs with explicit review:human label

### DIFF
--- a/lib/services/review.ts
+++ b/lib/services/review.ts
@@ -44,10 +44,12 @@ export async function reviewPass(opts: {
 
     const issues = await provider.listIssuesByLabel(state.label);
     for (const issue of issues) {
-      // Skip agent-routed issues — the agent reviewer pipeline handles merge for those.
-      // reviewPass only handles externally-approved MRs (human review path).
+      // Only process issues explicitly marked for human review.
+      // review:agent → agent reviewer pipeline handles merge.
+      // No routing label → treat as agent by default (safe: never auto-merge without explicit human approval).
+      // review:human → human approved on provider; heartbeat handles merge transition.
       const routing = detectStepRouting(issue.labels, "review");
-      if (routing === "agent") continue;
+      if (routing !== "human") continue;
 
       const status = await provider.getPrStatus(issue.iid);
 


### PR DESCRIPTION
## Root Cause

`reviewPass` in `review.ts` used:
```ts
if (routing === "agent") continue;  // skip agent-routed
```

This correctly skipped `review:agent` issues, but **silently processed issues with NO routing label** as if they were human-reviewed. Since the routing label (`review:agent`/`review:human`) is applied best-effort during developer dispatch, a failed label write left issues unguarded — the next heartbeat tick would auto-merge the PR as soon as it appeared approved or merged.

## Fix

Change the guard to **require an explicit opt-in**:
```ts
if (routing !== "human") continue;  // only process explicitly human-routed
```

Behaviour after the fix:
| Label | Before fix | After fix |
|-------|-----------|-----------|
| `review:human` | ✅ processed (merge on approval) | ✅ processed (merge on approval) |
| `review:agent` | ❌ skipped | ❌ skipped |
| *(none)* | ⚠️ **auto-merged (BUG)** | ❌ skipped (safe) |

## Tests

- Updated 4 existing `reviewPass` tests: no-routing-label issues → `review:human` (they were always testing the human-review path)
- Added new regression test: **"should skip issues with no routing label"** — seeds an approved PR on an issue with only `["To Review"]` and asserts 0 transitions + 0 `mergePr` calls

138 tests pass. TypeScript compiles clean.

Addresses issue #208