### PR TITLE
docs: fix stale research_task descriptions in tool description and templates.ts

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -262,7 +262,7 @@ All orchestration goes through these tools. You do NOT manually manage sessions,
 | \`health\` | Scan worker health: zombies, stale workers, orphaned state. Pass fix=true to auto-fix |
 | \`work_start\` | End-to-end: label transition, level assignment, session create/reuse, dispatch with role instructions |
 | \`work_finish\` | End-to-end: label transition, state update, issue close/reopen |
-| \`research_task\` | Spawn an architect for design investigation. Creates Planning issue with rich context and dispatches architect |
+| \`research_task\` | Dispatch architect to research; Planning issue created from findings when architect calls \`work_finish\` |
 
 ### First Thing on Session Start
 
@@ -278,7 +278,7 @@ Planning → To Do → Doing → To Review ──┬── [agent] → Reviewing
 
 To Improve → Doing (fix cycle)
 Refining (human decision)
-research_task → Planning (architect researches, posts findings, stays in Planning)
+research_task → [architect researches, no issue yet] → work_finish → Planning (created with findings)
 \`\`\`
 
 Review policy (configurable per project in workflow.yaml):

--- a/lib/tools/research-task.ts
+++ b/lib/tools/research-task.ts
@@ -22,7 +22,7 @@ export function createResearchTaskTool(api: OpenClawPluginApi) {
   return (ctx: ToolContext) => ({
     name: "research_task",
     label: "Research Task",
-    description: `Spawn an architect to research a design/architecture problem. Creates a Planning issue and dispatches an architect worker.
+    description: `Spawn an architect to research a design/architecture problem. Dispatches architect directly — no issue created yet. The architect calls \`work_finish(result='done', summary='<findings>')\` which creates the Planning issue for human review.
 
 IMPORTANT: Provide a detailed description with enough background context for the architect
 to produce actionable, development-ready findings. Include: current state, constraints,


### PR DESCRIPTION
Fixes stale descriptions that incorrectly say 'Creates a Planning issue' when the issue is actually created after the architect calls work_finish.

As described in issue #206

## Changes

1. **lib/tools/research-task.ts** - Updated tool description to clarify that no issue is created at dispatch time
2. **lib/templates.ts** - Updated AGENTS.md scaffold table and pipeline flow documentation

Addresses issue #206