### PR TITLE
fix: prevent self-merged PRs from bypassing review:human gate (#215)

### DIFF
--- a/lib/services/review.ts
+++ b/lib/services/review.ts
@@ -55,9 +55,12 @@ export async function reviewPass(opts: {
 
       const status = await provider.getPrStatus(issue.iid);
 
+      // Strict separation: PR_APPROVED requires an actual review approval (not just a merge).
+      // PR_MERGED only triggers on merge. This prevents self-merged PRs (no reviews) from
+      // bypassing the review:human gate — a developer merging their own PR must not pass as approved.
       const conditionMet =
         (state.check === ReviewCheck.PR_MERGED && status.state === PrState.MERGED) ||
-        (state.check === ReviewCheck.PR_APPROVED && (status.state === PrState.APPROVED || status.state === PrState.MERGED));
+        (state.check === ReviewCheck.PR_APPROVED && status.state === PrState.APPROVED);
 
       if (!conditionMet) continue;
 


### PR DESCRIPTION
## Summary

Addresses issue #215 — three fixes to prevent developers from bypassing the `review:human` gate by self-merging their PRs.

## Bug

1. **AGENTS.md** instructed developers to *merge* before announcing completion — contradicting `developer.md`'s 'don't merge' rule
2. **review.ts** treated `PrState.MERGED` as equivalent to `PrState.APPROVED` for the `prApproved` check — so a self-merged PR auto-passed the human review gate
3. **github.ts** didn't fetch `reviewDecision` for merged PRs — no way to distinguish approved+merged from self-merged

## Fixes

### Fix 1: AGENTS.md (workspace file — not in this repo)
Updated instruction from:
> DEVELOPER must merge to base branch before announcing completion

To:
> DEVELOPER must create a PR to the base branch. Do NOT merge. The review pipeline handles merging after approval.

### Fix 2: `lib/services/review.ts`
Strict separation of `PR_APPROVED` and `PR_MERGED` checks:
```ts
// Before (bug):
(state.check === ReviewCheck.PR_APPROVED && (status.state === PrState.APPROVED || status.state === PrState.MERGED))

// After (fixed):
(state.check === ReviewCheck.PR_APPROVED && status.state === PrState.APPROVED)
```

### Fix 3: `lib/providers/github.ts`
Now fetches `reviewDecision` for merged PRs — returns `PrState.APPROVED` if the PR was approved before merge, `PrState.MERGED` otherwise. Self-merged PRs (no reviews) correctly return `PrState.MERGED` and don't pass the `prApproved` gate.

## Tests
**200/200 pass** — no regressions