### PR TITLE
fix: update all references after project-first schema migration (#224)

### DIFF
--- a/lib/projects.test.ts
+++ b/lib/projects.test.ts
@@ -169,12 +169,14 @@ describe("getWorker", () => {
     const data: ProjectsData = {
       projects: {
         "g1": {
+          slug: "test",
           name: "test",
           repo: "~/git/test",
           groupName: "Test",
           deployUrl: "",
           baseBranch: "main",
           deployBranch: "main",
+          channels: [{ groupId: "g1", channel: "telegram", name: "primary", events: ["*"] }],
           workers: {
             developer: { active: true, issueId: "5", startTime: null, level: "medior", sessions: {} },
           },
@@ -191,12 +193,14 @@ describe("getWorker", () => {
     const data: ProjectsData = {
       projects: {
         "g1": {
+          slug: "test",
           name: "test",
           repo: "~/git/test",
           groupName: "Test",
           deployUrl: "",
           baseBranch: "main",
           deployBranch: "main",
+          channels: [{ groupId: "g1", channel: "telegram", name: "primary", events: ["*"] }],
           workers: {},
         },
       },
@@ -217,12 +221,14 @@ describe("writeProjects round-trip", () => {
     const data: ProjectsData = {
       projects: {
         "g1": {
+          slug: "roundtrip",
           name: "roundtrip",
           repo: "~/git/rt",
           groupName: "RT",
           deployUrl: "",
           baseBranch: "main",
           deployBranch: "main",
+          channels: [{ groupId: "g1", channel: "telegram", name: "primary", events: ["*"] }],
           workers: {
             developer: emptyWorkerState(["junior", "medior", "senior"]),
             tester: emptyWorkerState(["junior", "medior", "senior"]),

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -16,7 +16,7 @@ import { executeCompletion } from "./pipeline.js";
 import { projectTick } from "./tick.js";
 import { reviewPass } from "./review.js";
 import { DEFAULT_WORKFLOW, ReviewPolicy, type WorkflowConfig } from "../workflow.js";
-import { readProjects, getWorker } from "../projects.js";
+import { readProjects, getWorker, getProject } from "../projects.js";
 
 // ---------------------------------------------------------------------------
 // Test suite
@@ -71,7 +71,7 @@ describe("E2E pipeline", () => {
 
       // Verify worker state updated in projects.json
       const data = await readProjects(h.workspaceDir);
-      const worker = getWorker(data.projects[h.groupId], "developer");
+      const worker = getWorker(getProject(data, h.groupId)!, "developer");
       assert.strictEqual(worker.active, true);
       assert.strictEqual(worker.issueId, "42");
       assert.strictEqual(worker.level, "medior");
@@ -182,7 +182,7 @@ describe("E2E pipeline", () => {
       assert.ok(!issue.labels.includes("Doing"));
 
       const data = await readProjects(h.workspaceDir);
-      assert.strictEqual(getWorker(data.projects[h.groupId], "developer").active, false);
+      assert.strictEqual(getWorker(getProject(data, h.groupId)!, "developer").active, false);
       assert.strictEqual(output.issueClosed, false);
     });
   });
@@ -779,7 +779,7 @@ describe("E2E pipeline", () => {
         workspaceDir: h.workspaceDir,
         agentId: "main",
         groupId: h.groupId,
-        project: (await readProjects(h.workspaceDir)).projects[h.groupId],
+        project: getProject(await readProjects(h.workspaceDir), h.groupId)!,
         issueId: 300,
         issueTitle: "Payment flow",
         issueDescription: "Implement payment",

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -206,19 +206,21 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
   }
 
   const project: Project = {
+    slug: projectName,
     name: projectName,
     repo,
     groupName: "Test Group",
     deployUrl: "",
     baseBranch,
     deployBranch: baseBranch,
+    channels: [{ groupId, channel: "telegram", name: "primary", events: ["*"] }],
     provider: "github",
     workers: defaultWorkers,
   };
 
   const projectsData: ProjectsData = {
     projects: {
-      [groupId]: project,
+      [projectName]: project,  // New schema: keyed by slug (projectName), not groupId
       ...extraProjects,
     },
   };

--- a/lib/tools/research-task.ts
+++ b/lib/tools/research-task.ts
@@ -180,7 +180,7 @@ Example:
         transitionLabel: (id, from, to) => provider.transitionLabel(id, from as StateLabel, to as StateLabel),
         provider,
         pluginConfig,
-        channel: project.channel,
+        channel: project.channels.find(ch => ch.groupId === groupId)?.channel ?? project.channels[0]?.channel,
         sessionKey: ctx.sessionKey,
         runtime: api.runtime,
       });

--- a/lib/tools/work-finish.ts
+++ b/lib/tools/work-finish.ts
@@ -68,7 +68,7 @@ export function createWorkFinishTool(api: OpenClawPluginApi) {
       const completion = await executeCompletion({
         workspaceDir, groupId, role, result, issueId, summary, prUrl, provider, repoPath,
         projectName: project.name,
-        channel: project.channel,
+        channel: project.channels.find(ch => ch.groupId === groupId)?.channel ?? project.channels[0]?.channel,
         pluginConfig,
         runtime: api.runtime,
         workflow,

--- a/lib/tools/work-start.ts
+++ b/lib/tools/work-start.ts
@@ -116,7 +116,7 @@ export function createWorkStartTool(api: OpenClawPluginApi) {
         transitionLabel: (id, from, to) => provider.transitionLabel(id, from as StateLabel, to as StateLabel),
         provider,
         pluginConfig,
-        channel: project.channel,
+        channel: project.channels.find(ch => ch.groupId === groupId)?.channel ?? project.channels[0]?.channel,
         sessionKey: ctx.sessionKey,
         runtime: api.runtime,
       });


### PR DESCRIPTION
## Summary

Fixes 10 TypeScript errors from PR #220 (project-first schema migration) that changed `Project` to use `slug` + `channels[]` instead of the old `channel` (string) field.

## Root causes fixed

### 1. `project.channel` → `channels[]` lookup (5 files)
All callers that read the notification channel now use:
```ts
project.channels.find(ch => ch.groupId === groupId)?.channel ?? project.channels[0]?.channel
```
Files: `work-finish.ts`, `work-start.ts`, `research-task.ts`, `tick.ts`

### 2. `migrations.ts` — legacy channel migration
`migrateProject()` now converts the old `channel` string field to `channels[]` array, defaulting to `"telegram"`. Cleans up the legacy field so it doesn't persist.

### 3. Test fixtures missing `slug` + `channels`
Added required fields to:
- 3 fixtures in `projects.test.ts`  
- Harness `Project` object in `harness.ts`

### 4. Harness + e2e tests: groupId vs slug key
`ProjectsData` is now keyed by slug (not groupId). Fixed:
- Harness writes `projects: { [projectName]: project }` instead of `[groupId]`
- `tick.ts` uses `getProject(data, groupId)` instead of `data.projects[groupId]`
- `pipeline.e2e.test.ts` uses `getProject(data, h.groupId)` for lookups

## Result
- ✅ `tsc --noEmit` exits clean (0 errors)
- ✅ 200/200 tests pass