### PR TITLE
fix: health check false-kills workers due to session cap and wrong revert label

### DIFF
--- a/lib/dispatch.ts
+++ b/lib/dispatch.ts
@@ -274,7 +274,7 @@ export async function dispatchTask(
   // Step 5: Update worker state
   try {
     await recordWorkerState(workspaceDir, groupId, role, {
-      issueId, level, sessionKey, sessionAction,
+      issueId, level, sessionKey, sessionAction, fromLabel,
     });
   } catch (err) {
     // Session is already dispatched — log warning but don't fail
@@ -346,13 +346,14 @@ function sendToAgent(
 
 async function recordWorkerState(
   workspaceDir: string, groupId: string, role: string,
-  opts: { issueId: number; level: string; sessionKey: string; sessionAction: "spawn" | "send" },
+  opts: { issueId: number; level: string; sessionKey: string; sessionAction: "spawn" | "send"; fromLabel?: string },
 ): Promise<void> {
   await activateWorker(workspaceDir, groupId, role, {
     issueId: String(opts.issueId),
     level: opts.level,
     sessionKey: opts.sessionKey,
     startTime: new Date().toISOString(),
+    previousLabel: opts.fromLabel,
   });
 }
 

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -83,6 +83,8 @@ export type WorkerState = {
   startTime: string | null;
   level: string | null;
   sessions: Record<string, string | null>;
+  /** Label the issue had before being transitioned to the active (Doing/Testing) state. Used by health check to revert to the correct queue label. */
+  previousLabel?: string | null;
 };
 
 /**
@@ -288,6 +290,7 @@ export async function updateWorker(
 /**
  * Mark a worker as active with a new task.
  * Stores session key in sessions[level] when a new session is spawned.
+ * Stores previousLabel so health check can revert to the correct queue state.
  * Accepts slug or groupId (dual-mode).
  */
 export async function activateWorker(
@@ -299,6 +302,8 @@ export async function activateWorker(
     level: string;
     sessionKey?: string;
     startTime?: string;
+    /** Label the issue had before transitioning to the active state (e.g. "To Do", "To Improve"). */
+    previousLabel?: string;
   },
 ): Promise<ProjectsData> {
   const updates: Partial<WorkerState> = {
@@ -311,6 +316,9 @@ export async function activateWorker(
   }
   if (params.startTime !== undefined) {
     updates.startTime = params.startTime;
+  }
+  if (params.previousLabel !== undefined) {
+    updates.previousLabel = params.previousLabel;
   }
   return updateWorker(workspaceDir, slugOrGroupId, role, updates);
 }


### PR DESCRIPTION
Addresses issue #225

## Changes

### P0: Fix session liveness check (health.ts)
- `fetchGatewaySessions()` now reads session files directly via `sessions.paths` from the gateway status response, bypassing the `sessions.recent` cap of 10 entries
- Falls back to `sessions.recent` if all file reads fail (e.g. permission issues)

### P1: Grace period (health.ts)
- Added `GRACE_PERIOD_MS = 5 minutes` constant
- Session-dead checks are skipped for workers started within the grace period (they may not appear in gateway sessions yet)

### P1: Track previousLabel in WorkerState (projects.ts + dispatch.ts)
- Added `previousLabel?: string | null` to `WorkerState` type
- `activateWorker()` now accepts and stores `previousLabel`
- `dispatchTask()` → `recordWorkerState()` passes `fromLabel` as `previousLabel`
- `checkWorkerHealth()` uses `worker.previousLabel ?? getRevertLabel()` for reverts, ensuring `To Improve → Doing` reverts to `To Improve` not `To Do`

## Testing
- `npm run build` (tsc) passes with no errors