### PR TITLE
feat: detect and cleanup orphaned subagent sessions in health pass

### DIFF
--- a/lib/services/health.ts
+++ b/lib/services/health.ts
@@ -21,7 +21,9 @@ import {
   getSessionForLevel,
   getWorker,
   updateWorker,
+  readProjects,
   type Project,
+  type ProjectsData,
 } from "../projects.js";
 import { runCommand } from "../run-command.js";
 import {
@@ -45,7 +47,8 @@ export type HealthIssue = {
     | "stuck_label"          // Case 4: inactive but issue still has active label
     | "orphan_issue_id"      // Case 5: inactive but issueId set
     | "issue_gone"           // Case 6: active but issue deleted/closed
-    | "orphaned_label";      // Case 7: active label but no worker tracking it
+    | "orphaned_label"        // Case 7: active label but no worker tracking it
+    | "orphaned_session";    // Case 8: gateway session exists but not tracked in projects.json
   severity: "critical" | "warning";
   project: string;
   groupId: string;
@@ -95,11 +98,22 @@ export async function fetchGatewaySessions(gatewayTimeoutMs = 15_000): Promise<S
 
     const jsonStart = result.stdout.indexOf("{");
     const data = JSON.parse(jsonStart >= 0 ? result.stdout.slice(jsonStart) : result.stdout);
-    const sessions: GatewaySession[] = data?.sessions?.recent ?? [];
-
-    for (const session of sessions) {
-      if (session.key) {
-        lookup.set(session.key, session);
+    // Use byAgent (full list per agent) when available, fall back to recent (capped)
+    const byAgent: Array<{ agentId: string; recent: GatewaySession[] }> = data?.sessions?.byAgent ?? [];
+    if (byAgent.length > 0) {
+      for (const agent of byAgent) {
+        for (const session of agent.recent ?? []) {
+          if (session.key) {
+            lookup.set(session.key, session);
+          }
+        }
+      }
+    } else {
+      const sessions: GatewaySession[] = data?.sessions?.recent ?? [];
+      for (const session of sessions) {
+        if (session.key) {
+          lookup.set(session.key, session);
+        }
       }
     }
     return lookup;
@@ -490,6 +504,98 @@ export async function scanOrphanedLabels(opts: {
 
       fixes.push(fix);
     }
+  }
+
+  return fixes;
+}
+
+// ---------------------------------------------------------------------------
+// Orphaned session scan
+// ---------------------------------------------------------------------------
+
+/** Subagent session key pattern: agent:{agentId}:subagent:{project}-{role}-{level} */
+const SUBAGENT_PATTERN = /^agent:[^:]+:subagent:/;
+
+/**
+ * Scan for gateway subagent sessions that are NOT tracked in any project's
+ * worker sessions map. These are leftover from previous dispatches at
+ * different levels and waste resources / contribute to session cap pressure.
+ *
+ * Returns fixes for all orphaned sessions found.
+ */
+export async function scanOrphanedSessions(opts: {
+  workspaceDir: string;
+  sessions: SessionLookup | null;
+  autoFix: boolean;
+}): Promise<HealthFix[]> {
+  const { workspaceDir, sessions, autoFix } = opts;
+  const fixes: HealthFix[] = [];
+
+  // Skip if gateway unavailable
+  if (!sessions) return fixes;
+
+  // 1. Collect all known (tracked) session keys from projects.json
+  const knownKeys = new Set<string>();
+  const activeSessionKeys = new Set<string>();
+
+  let data: ProjectsData;
+  try {
+    data = await readProjects(workspaceDir);
+  } catch {
+    return fixes; // Can't read projects — skip
+  }
+
+  for (const project of Object.values(data.projects)) {
+    for (const [_role, worker] of Object.entries(project.workers)) {
+      for (const [_level, sessionKey] of Object.entries(worker.sessions)) {
+        if (sessionKey) {
+          knownKeys.add(sessionKey);
+          // Track active worker sessions (belt-and-suspenders: never delete these)
+          if (worker.active) {
+            activeSessionKeys.add(sessionKey);
+          }
+        }
+      }
+    }
+  }
+
+  // 2. Find subagent sessions in gateway that aren't tracked
+  for (const [key, _session] of sessions) {
+    // Only consider subagent sessions
+    if (!SUBAGENT_PATTERN.test(key)) continue;
+
+    // Skip if tracked in projects.json
+    if (knownKeys.has(key)) continue;
+
+    // Belt-and-suspenders: never delete active worker sessions
+    if (activeSessionKeys.has(key)) continue;
+
+    const fix: HealthFix = {
+      issue: {
+        type: "orphaned_session",
+        severity: "warning",
+        project: "global",
+        groupId: "global",
+        role: "developer", // Placeholder — role is embedded in session key
+        sessionKey: key,
+        message: `Gateway session "${key}" is not tracked by any project worker`,
+      },
+      fixed: false,
+    };
+
+    if (autoFix) {
+      try {
+        await runCommand(
+          ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key })],
+          { timeoutMs: 10_000 },
+        );
+        fix.fixed = true;
+      } catch {
+        // Deletion failed — report but don't crash
+      }
+    }
+
+    fixes.push(fix);
   }
 
   return fixes;

--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -16,7 +16,7 @@ import path from "node:path";
 import { readProjects, getProject } from "../projects.js";
 import { log as auditLog } from "../audit.js";
 import { DATA_DIR } from "../setup/migrate-layout.js";
-import { checkWorkerHealth, scanOrphanedLabels, fetchGatewaySessions, type SessionLookup } from "./health.js";
+import { checkWorkerHealth, scanOrphanedLabels, scanOrphanedSessions, fetchGatewaySessions, type SessionLookup } from "./health.js";
 import { projectTick } from "./tick.js";
 import { reviewPass } from "./review.js";
 import { createProvider } from "../providers/index.js";
@@ -344,6 +344,14 @@ export async function tick(opts: {
       result.totalSkipped++;
     }
   }
+
+  // Orphaned session scan: clean up subagent sessions not tracked by any project
+  const orphanedSessionFixes = await scanOrphanedSessions({
+    workspaceDir,
+    sessions,
+    autoFix: true,
+  });
+  result.totalHealthFixes += orphanedSessionFixes.filter((f) => f.fixed).length;
 
   await auditLog(workspaceDir, "heartbeat_tick", {
     projectsScanned: slugs.length,


### PR DESCRIPTION
As described in issue #227

## Changes

- **health.ts**: Added `scanOrphanedSessions()` function that collects all tracked session keys from projects.json, diffs against gateway subagent sessions, and reports/deletes orphans. Added `orphaned_session` to `HealthIssue.type` union. Enhanced `fetchGatewaySessions()` to use `byAgent` (full session list per agent) instead of `sessions.recent` (capped at 10).

- **heartbeat.ts**: Calls `scanOrphanedSessions()` after the project loop with `autoFix: true`.

- **tools/health.ts**: Calls `scanOrphanedSessions()` so users see orphaned sessions in health output.

## Safety
- Only targets subagent sessions (pattern: `agent:*:subagent:*`)
- Never deletes active worker sessions (belt-and-suspenders check)
- Skips when gateway is unavailable
- Uses `sessions.delete` gateway API for clean deletion