### PR TITLE
feat: run immediate tick 2s after heartbeat service startup

### DIFF
--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -103,6 +103,14 @@ export function registerHeartbeatService(api: OpenClawPluginApi) {
         () => runHeartbeatTick(agents, config, pluginConfig, ctx.logger),
         config.intervalSeconds * 1000,
       );
+
+      // Run an immediate tick shortly after startup so queued work is picked up
+      // right away instead of waiting for the full interval (up to 60s).
+      // The 2s delay lets the plugin and providers fully initialize first.
+      setTimeout(
+        () => runHeartbeatTick(agents, config, pluginConfig, ctx.logger),
+        2_000,
+      );
     },
 
     stop: async (ctx) => {


### PR DESCRIPTION
Addresses issue #232

After a gateway restart the heartbeat used to wait up to 60s (the full interval) before processing queued work. This adds a one-shot `setTimeout(2000)` right after `setInterval` in the service `start` handler, so the first tick fires ~2 seconds post-startup while the regular periodic interval continues unchanged.

## Change
`lib/services/heartbeat.ts` — 8 lines added after the `setInterval` call in `registerHeartbeatService`.

## Testing
- `npm run build` (tsc) passes with no errors