### PR TITLE
feat: PR feedback detection, conflict detection, and review context passing

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -60,6 +60,24 @@ export type NotifyEvent =
       prTitle?: string;
       sourceBranch?: string;
       mergedBy: "heartbeat" | "agent" | "pipeline";
+    }
+  | {
+      type: "changesRequested";
+      project: string;
+      groupId: string;
+      issueId: number;
+      issueUrl: string;
+      issueTitle: string;
+      prUrl?: string;
+    }
+  | {
+      type: "mergeConflict";
+      project: string;
+      groupId: string;
+      issueId: number;
+      issueUrl: string;
+      issueTitle: string;
+      prUrl?: string;
     };
 
 /**
@@ -122,6 +140,22 @@ function buildMessage(event: NotifyEvent): string {
       msg += `\n⚡ ${via[event.mergedBy] ?? event.mergedBy}`;
       if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
       msg += `\n📋 Issue: ${event.issueUrl}`;
+      return msg;
+    }
+
+    case "changesRequested": {
+      let msg = `⚠️ Changes requested on PR for #${event.issueId}: ${event.issueTitle}`;
+      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
+      msg += `\n📋 Issue: ${event.issueUrl}`;
+      msg += `\n→ Moving to To Improve for developer re-dispatch`;
+      return msg;
+    }
+
+    case "mergeConflict": {
+      let msg = `⚠️ Merge conflicts detected on PR for #${event.issueId}: ${event.issueTitle}`;
+      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
+      msg += `\n📋 Issue: ${event.issueUrl}`;
+      msg += `\n→ Moving to To Improve — developer will rebase and resolve`;
       return msg;
     }
   }

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -32,6 +32,7 @@ export type IssueComment = {
 export const PrState = {
   OPEN: "open",
   APPROVED: "approved",
+  CHANGES_REQUESTED: "changes_requested",
   MERGED: "merged",
   CLOSED: "closed",
 } as const;
@@ -44,6 +45,22 @@ export type PrStatus = {
   title?: string;
   /** Source branch name (e.g. "feature/7-blog-cms"). */
   sourceBranch?: string;
+  /** false = has merge conflicts. undefined = unknown or not applicable. */
+  mergeable?: boolean;
+};
+
+/** A review comment on a PR/MR. */
+export type PrReviewComment = {
+  id: number;
+  author: string;
+  body: string;
+  /** "APPROVED", "CHANGES_REQUESTED", "COMMENTED" */
+  state: string;
+  created_at: string;
+  /** File path for inline comments. */
+  path?: string;
+  /** Line number for inline comments. */
+  line?: number;
 };
 
 // ---------------------------------------------------------------------------
@@ -69,6 +86,10 @@ export interface IssueProvider {
   getPrStatus(issueId: number): Promise<PrStatus>;
   mergePr(issueId: number): Promise<void>;
   getPrDiff(issueId: number): Promise<string | null>;
+  /** Get review comments on the PR linked to an issue. */
+  getPrReviewComments(issueId: number): Promise<PrReviewComment[]>;
+  /** React to a PR comment with an emoji (e.g. "+1"). Best-effort. */
+  reactToPrComment(issueId: number, commentId: number, emoji: string): Promise<void>;
   addComment(issueId: number, body: string): Promise<void>;
   editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue>;
   healthCheck(): Promise<boolean>;

--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -319,6 +319,21 @@ export async function tick(opts: {
             ).catch(() => {});
           }).catch(() => {});
         },
+        onFeedback: (issueId, reason, prUrl, issueTitle, issueUrl) => {
+          const type = reason === "changes_requested" ? "changesRequested" as const : "mergeConflict" as const;
+          notify(
+            {
+              type,
+              project: project.name,
+              groupId: primaryGroupId,
+              issueId,
+              issueUrl,
+              issueTitle,
+              prUrl: prUrl ?? undefined,
+            },
+            { workspaceDir, config: notifyConfig, groupId: primaryGroupId, channel: project.channels[0]?.channel ?? "telegram" },
+          ).catch(() => {});
+        },
       });
 
       // Budget check: stop if we've hit the limit

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -46,6 +46,8 @@ export type ProviderCall =
   | { method: "getPrStatus"; args: { issueId: number } }
   | { method: "mergePr"; args: { issueId: number } }
   | { method: "getPrDiff"; args: { issueId: number } }
+  | { method: "getPrReviewComments"; args: { issueId: number } }
+  | { method: "reactToPrComment"; args: { issueId: number; commentId: number; emoji: string } }
   | { method: "addComment"; args: { issueId: number; body: string } }
   | { method: "editIssue"; args: { issueId: number; updates: { title?: string; body?: string } } }
   | { method: "healthCheck"; args: {} };
@@ -267,6 +269,14 @@ export class TestProvider implements IssueProvider {
   async getPrDiff(issueId: number): Promise<string | null> {
     this.calls.push({ method: "getPrDiff", args: { issueId } });
     return this.prDiffs.get(issueId) ?? null;
+  }
+
+  async getPrReviewComments(_issueId: number): Promise<import("../providers/provider.js").PrReviewComment[]> {
+    return [];
+  }
+
+  async reactToPrComment(_issueId: number, _commentId: number, _emoji: string): Promise<void> {
+    // no-op in tests
   }
 
   async addComment(issueId: number, body: string): Promise<void> {

--- a/lib/workflow.ts
+++ b/lib/workflow.ts
@@ -65,6 +65,8 @@ export const WorkflowEvent = {
   REVIEW: "REVIEW",
   APPROVED: "APPROVED",
   MERGE_FAILED: "MERGE_FAILED",
+  CHANGES_REQUESTED: "CHANGES_REQUESTED",
+  MERGE_CONFLICT: "MERGE_CONFLICT",
   PASS: "PASS",
   FAIL: "FAIL",
   REFINE: "REFINE",
@@ -146,6 +148,8 @@ export const DEFAULT_WORKFLOW: WorkflowConfig = {
         [WorkflowEvent.PICKUP]: "reviewing",
         [WorkflowEvent.APPROVED]: { target: "toTest", actions: [Action.MERGE_PR, Action.GIT_PULL] },
         [WorkflowEvent.MERGE_FAILED]: "toImprove",
+        [WorkflowEvent.CHANGES_REQUESTED]: "toImprove",
+        [WorkflowEvent.MERGE_CONFLICT]: "toImprove",
       },
     },
     reviewing: {


### PR DESCRIPTION
As described in issue #239

## Summary

Implements full PR/MR feedback loop: detect changes requested + merge conflicts on heartbeat, pass review comments to developer on re-dispatch, and notification support.

## Changes (9 files, ~370 lines)

### Core Types
- **provider.ts**: Added `CHANGES_REQUESTED` to `PrState`, `mergeable` field to `PrStatus`, `PrReviewComment` type, `getPrReviewComments()` and `reactToPrComment()` to `IssueProvider`
- **workflow.ts**: Added `CHANGES_REQUESTED` and `MERGE_CONFLICT` workflow events with transitions `toReview → toImprove`

### Provider Implementations
- **github.ts**: Detect changes requested via `reviewDecision` + individual reviews fallback (for repos without branch protection). Detect conflicts via `mergeable` field. New `getPrReviewComments()` fetches both review-level and inline comments. `reactToPrComment()` adds emoji reactions.
- **gitlab.ts**: Detect changes requested via unresolved discussion threads. Detect conflicts via `detailed_merge_status`/`has_conflicts`. New `getPrReviewComments()` fetches from discussions API. `reactToPrComment()` uses award emoji.

### Pipeline Integration
- **review.ts**: Extended `reviewPass()` to detect `CHANGES_REQUESTED` and `MERGE_CONFLICT` states and transition accordingly. Added `onFeedback` callback for notifications.
- **dispatch.ts**: When re-dispatching developer from To Improve, fetches PR review comments and includes them in task message. Includes rebase instructions for merge conflicts.
- **heartbeat.ts**: Wires up `onFeedback` callback to send notifications
- **notify.ts**: Added `changesRequested` and `mergeConflict` notification types

### Tests
- **test-provider.ts**: Added stub implementations of new interface methods
- All 179 tests pass