### PR TITLE
feat: use inline markdown links in all notifications

### DIFF
--- a/lib/dispatch.ts
+++ b/lib/dispatch.ts
@@ -432,5 +432,5 @@ function buildAnnouncement(
 ): string {
   const emoji = resolvedRole?.emoji[level] ?? getFallbackEmoji(role);
   const actionVerb = sessionAction === "spawn" ? "Spawning" : "Sending";
-  return `${emoji} ${actionVerb} ${role.toUpperCase()} (${level}) for #${issueId}: ${issueTitle}\n🔗 ${issueUrl}`;
+  return `${emoji} ${actionVerb} ${role.toUpperCase()} (${level}) for #${issueId}: ${issueTitle}\n🔗 [Issue #${issueId}](${issueUrl})`;
 }

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -81,7 +81,7 @@ function buildMessage(event: NotifyEvent): string {
   switch (event.type) {
     case "workerStart": {
       const action = event.sessionAction === "spawn" ? "🚀 Started" : "▶️ Resumed";
-      return `${action} ${event.role.toUpperCase()} (${event.level}) on #${event.issueId}: ${event.issueTitle}\n🔗 ${event.issueUrl}`;
+      return `${action} ${event.role.toUpperCase()} (${event.level}) on #${event.issueId}: ${event.issueTitle}\n🔗 [Issue #${event.issueId}](${event.issueUrl})`;
     }
 
     case "workerComplete": {
@@ -108,8 +108,8 @@ function buildMessage(event: NotifyEvent): string {
       if (event.nextState) {
         msg += ` → ${event.nextState}`;
       }
-      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
-      msg += `\n📋 Issue: ${event.issueUrl}`;
+      if (event.prUrl) msg += `\n🔗 [PR](${event.prUrl})`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       return msg;
     }
 
@@ -117,8 +117,8 @@ function buildMessage(event: NotifyEvent): string {
       const icon = event.routing === "human" ? "👀" : "🤖";
       const who = event.routing === "human" ? "Human review needed" : "Agent review queued";
       let msg = `${icon} ${who} for #${event.issueId}: ${event.issueTitle}`;
-      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
-      msg += `\n📋 Issue: ${event.issueUrl}`;
+      if (event.prUrl) msg += `\n🔗 [PR](${event.prUrl})`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       return msg;
     }
 
@@ -132,23 +132,23 @@ function buildMessage(event: NotifyEvent): string {
       if (event.prTitle) msg += `\n📝 ${event.prTitle}`;
       if (event.sourceBranch) msg += `\n🌿 ${event.sourceBranch} → main`;
       msg += `\n⚡ ${via[event.mergedBy] ?? event.mergedBy}`;
-      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
-      msg += `\n📋 Issue: ${event.issueUrl}`;
+      if (event.prUrl) msg += `\n🔗 [PR](${event.prUrl})`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       return msg;
     }
 
     case "changesRequested": {
       let msg = `⚠️ Changes requested on PR for #${event.issueId}: ${event.issueTitle}`;
-      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
-      msg += `\n📋 Issue: ${event.issueUrl}`;
+      if (event.prUrl) msg += `\n🔗 [PR](${event.prUrl})`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       msg += `\n→ Moving to To Improve for developer re-dispatch`;
       return msg;
     }
 
     case "mergeConflict": {
       let msg = `⚠️ Merge conflicts detected on PR for #${event.issueId}: ${event.issueTitle}`;
-      if (event.prUrl) msg += `\n🔗 PR: ${event.prUrl}`;
-      msg += `\n📋 Issue: ${event.issueUrl}`;
+      if (event.prUrl) msg += `\n🔗 [PR](${event.prUrl})`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       msg += `\n→ Moving to To Improve — developer will rebase and resolve`;
       return msg;
     }

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -225,8 +225,8 @@ export async function executeCompletion(opts: {
   const label = key.replace(":", " ").toUpperCase();
   let announcement = `${emoji} ${label} #${issueId}`;
   if (summary) announcement += ` — ${summary}`;
-  announcement += `\n📋 Issue: ${issue.web_url}`;
-  if (prUrl) announcement += `\n🔗 PR: ${prUrl}`;
+  announcement += `\n📋 [Issue #${issueId}](${issue.web_url})`;
+  if (prUrl) announcement += `\n🔗 [PR](${prUrl})`;
   announcement += `\n${nextState}.`;
 
   return {

--- a/lib/tools/research-task.ts
+++ b/lib/tools/research-task.ts
@@ -160,7 +160,7 @@ Example:
             status: "queued",
             reason: `${role.toUpperCase()} already active on #${worker.issueId}. Research ticket queued — architect will pick it up when current work completes.`,
           },
-          announcement: `📐 Created research ticket #${issue.iid}: ${title} (architect busy — queued)\n🔗 ${issue.web_url}`,
+          announcement: `📐 Created research ticket #${issue.iid}: ${title} (architect busy — queued)\n🔗 [Issue #${issue.iid}](${issue.web_url})`,
         });
       }
 

--- a/lib/tools/task-create.ts
+++ b/lib/tools/task-create.ts
@@ -95,7 +95,7 @@ Examples:
       const hasBody = description && description.trim().length > 0;
       let announcement = `📋 Created #${issue.iid}: "${title}" (${label})`;
       if (hasBody) announcement += "\nWith detailed description.";
-      announcement += `\n🔗 ${issue.web_url}`;
+      announcement += `\n🔗 [Issue #${issue.iid}](${issue.web_url})`;
       announcement += pickup ? "\nPicking up for DEV..." : "\nReady for pickup when needed.";
 
       return jsonResult({

--- a/lib/tools/task-edit-body.ts
+++ b/lib/tools/task-edit-body.ts
@@ -119,7 +119,7 @@ Examples:
           issueUrl: issue.web_url,
           project: project.name,
           changed: false,
-          announcement: `Issue #${issueId} already has the requested content — no changes made.\n🔗 ${issue.web_url}`,
+          announcement: `Issue #${issueId} already has the requested content — no changes made.\n🔗 [Issue #${issueId}](${issue.web_url})`,
         });
       }
 
@@ -169,7 +169,7 @@ Examples:
       const changedFields = Object.keys(changes).join(" and ");
       let announcement = `✏️ Updated ${changedFields} of #${issueId}: "${updatedIssue.title}"`;
       if (reason) announcement += ` — ${reason}`;
-      announcement += `\n🔗 ${updatedIssue.web_url}`;
+      announcement += `\n🔗 [Issue #${issueId}](${updatedIssue.web_url})`;
 
       return jsonResult({
         success: true,


### PR DESCRIPTION
Addresses issue #243

Replaces all raw URLs in notification messages and announcement strings with `[text](URL)` inline markdown format. This prevents Telegram from generating link preview cards for every notification, keeping the chat clean.

## Files changed
- `lib/notify.ts` — all 6 `buildMessage()` event cases
- `lib/dispatch.ts` — `buildAnnouncement()`
- `lib/services/pipeline.ts` — `executeCompletion()` announcement
- `lib/tools/task-create.ts` — created issue announcement
- `lib/tools/research-task.ts` — queued research ticket announcement
- `lib/tools/task-edit-body.ts` — both no-change and updated announcements