### PR TITLE
feat: detect PR comments as feedback, transition to To Improve

### DIFF
--- a/lib/pr-context.ts
+++ b/lib/pr-context.ts
@@ -46,7 +46,7 @@ export async function fetchPrFeedback(
     if (reviewComments.length === 0) return undefined;
 
     const reason = prStatus.mergeable === false ? "merge_conflict" as const
-      : prStatus.state === PrState.CHANGES_REQUESTED ? "changes_requested" as const
+      : (prStatus.state === PrState.CHANGES_REQUESTED || prStatus.state === PrState.HAS_COMMENTS) ? "changes_requested" as const
       : "rejected" as const;
 
     return {

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -33,6 +33,8 @@ export const PrState = {
   OPEN: "open",
   APPROVED: "approved",
   CHANGES_REQUESTED: "changes_requested",
+  /** PR/MR is open with no formal review state, but has top-level comments from non-authors. */
+  HAS_COMMENTS: "has_comments",
   MERGED: "merged",
   CLOSED: "closed",
 } as const;

--- a/lib/services/review.ts
+++ b/lib/services/review.ts
@@ -62,8 +62,8 @@ export async function reviewPass(opts: {
         (state.check === ReviewCheck.PR_MERGED && status.state === PrState.MERGED) ||
         (state.check === ReviewCheck.PR_APPROVED && (status.state === PrState.APPROVED || status.state === PrState.MERGED));
 
-      // Changes requested → transition to toImprove
-      if (status.state === PrState.CHANGES_REQUESTED) {
+      // Changes requested or PR has comment feedback → transition to toImprove
+      if (status.state === PrState.CHANGES_REQUESTED || status.state === PrState.HAS_COMMENTS) {
         const changesTransition = state.on[WorkflowEvent.CHANGES_REQUESTED];
         if (changesTransition) {
           const targetKey = typeof changesTransition === "string" ? changesTransition : changesTransition.target;
@@ -73,7 +73,7 @@ export async function reviewPass(opts: {
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
-              reason: "changes_requested",
+              reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
               prUrl: status.url,
             });
             onFeedback?.(issue.iid, "changes_requested", status.url, issue.title, issue.web_url);


### PR DESCRIPTION
Addresses issue #245

## Problem
PR feedback detection only caught formal `CHANGES_REQUESTED` reviews. Regular PR/MR comments (e.g. "Can you change X?") were silently ignored, leaving issues stuck in "To Review" indefinitely.

## Solution
Add a new `PrState.HAS_COMMENTS` state that is returned when a PR/MR is open with no formal review decision but has top-level conversation comments from non-author users. The heartbeat's review pass treats `HAS_COMMENTS` exactly like `CHANGES_REQUESTED` — transitioning the issue to "To Improve" and including the comments in the developer re-dispatch context.

## Files changed

### `lib/providers/provider.ts`
- Add `PrState.HAS_COMMENTS = 'has_comments'`

### `lib/providers/github.ts`
- `getPrStatus()`: when open PR has no formal review/no CHANGES_REQUESTED, check top-level PR comments via `repos/:owner/:repo/issues/{pr}/comments` → return `HAS_COMMENTS` if non-author comments exist
- `getPrReviewComments()`: also include top-level conversation comments
- New private helpers: `getPrAuthor()`, `hasConversationComments()`, `fetchConversationComments()`

### `lib/providers/gitlab.ts`
- `getPrStatus()`: when open MR has no unresolved discussions, check regular notes via `/notes` endpoint → return `HAS_COMMENTS`
- `getPrReviewComments()`: also include regular MR notes, deduped
- New private helpers: `hasConversationComments()`, `fetchConversationComments()`

### `lib/services/review.ts`
- Handle `HAS_COMMENTS` same as `CHANGES_REQUESTED`: transition to toImprove

### `lib/pr-context.ts`
- Treat `HAS_COMMENTS` as `changes_requested` reason so comments appear in developer re-dispatch context