### PR TITLE
feat: improve Telegram notification formatting and add linkPreview to setup

### DIFF
--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -38,6 +38,7 @@ export async function writePluginConfig(
   ensureInternalHooks(config);
   ensureHeartbeatDefaults(config);
   configureSubagentCleanup(config);
+  ensureTelegramLinkPreviewDisabled(config);
 
   if (agentId) {
     addToolRestrictions(config, agentId);
@@ -89,5 +90,20 @@ function ensureHeartbeatDefaults(config: Record<string, unknown>): void {
   const devclaw = (config as any).plugins.entries.devclaw.config;
   if (!devclaw.work_heartbeat) {
     devclaw.work_heartbeat = { ...HEARTBEAT_DEFAULTS };
+  }
+}
+
+/**
+ * Disable Telegram link previews so notifications don't show URL preview cards.
+ * Sets channels.telegram.linkPreview = false if the Telegram channel is configured.
+ * Only sets if not already explicitly configured (respects user overrides).
+ */
+function ensureTelegramLinkPreviewDisabled(config: Record<string, unknown>): void {
+  const channels = config.channels as Record<string, unknown> | undefined;
+  if (!channels) return;
+  const telegram = channels.telegram as Record<string, unknown> | undefined;
+  if (!telegram) return;
+  if (telegram.linkPreview === undefined) {
+    telegram.linkPreview = false;
   }
 }


### PR DESCRIPTION
Addresses issue #254

## Changes

### `lib/notify.ts` — notification formatting

**`workerComplete` before:**
```
✅ DEVELOPER completed #252 — long summary text here → REVIEWER queue
🔗 [PR](url)
📋 [Issue #252](url)
```

**`workerComplete` after:**
```
✅ DEVELOPER completed #252
long summary text here
🔗 [Pull Request #253](url)
📋 [Issue #252](url)
→ REVIEWER queue
```

Changes:
- Summary on its own line (not crammed with ` — ` after header)
- Workflow transition (`→ REVIEWER queue`) moved to end, after links
- All PR/MR links: `[PR](url)` → `[Pull Request #N](url)` / `[Merge Request #N](url)` via `extractPrNumber()`
- New helpers: `extractPrNumber(url)`, `prLink(url)`

### `lib/setup/config.ts` — linkPreview in setup

Added `ensureTelegramLinkPreviewDisabled()` called from `writePluginConfig()`:
- Sets `channels.telegram.linkPreview = false` when Telegram is configured
- Only sets if not already explicitly configured (respects user overrides)
- Ensures all new DevClaw deployments have link previews disabled out of the box