### PR TITLE
feat: git history fallback for review transitions when no PR exists

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -446,6 +446,21 @@ export class GitHubProvider implements IssueProvider {
     return this.getIssue(issueId);
   }
 
+  /**
+   * Check if work for an issue is already present on the base branch via git log.
+   * Searches the last 200 commits on baseBranch for commit messages mentioning #issueId.
+   * Used as a fallback when no PR exists (e.g., direct commit to main).
+   */
+  async isCommitOnBaseBranch(issueId: number, baseBranch: string): Promise<boolean> {
+    try {
+      const result = await runCommand(
+        ["git", "log", `origin/${baseBranch}`, "--oneline", "-200", "--grep", `#${issueId}`],
+        { timeoutMs: 15_000, cwd: this.repoPath },
+      );
+      return result.stdout.trim().length > 0;
+    } catch { return false; }
+  }
+
   async healthCheck(): Promise<boolean> {
     try { await this.gh(["auth", "status"]); return true; } catch { return false; }
   }

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -88,6 +88,14 @@ export interface IssueProvider {
   /** Get review comments on the PR linked to an issue. */
   getPrReviewComments(issueId: number): Promise<PrReviewComment[]>;
   /**
+   * Check if work for an issue is already present on the base branch via git history.
+   * Used as a fallback when no PR exists (e.g., work committed directly to main).
+   * Searches recent git log on the base branch for commits mentioning issue #N or !N.
+   * @param issueId  Issue number to search for
+   * @param baseBranch  Branch to search (e.g. "main")
+   */
+  isCommitOnBaseBranch(issueId: number, baseBranch: string): Promise<boolean>;
+  /**
    * Add an emoji reaction to a PR/MR comment by its comment ID.
    * Best-effort — implementations should not throw.
    * @param issueId  Issue ID (used to locate the associated PR/MR)

--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -298,6 +298,7 @@ export async function tick(opts: {
         provider,
         repoPath: project.repo,
         gitPullTimeoutMs: resolvedConfig.timeouts.gitPullMs,
+        baseBranch: project.baseBranch,
         onMerge: (issueId, prUrl, prTitle, sourceBranch) => {
           provider.getIssue(issueId).then((issue) => {
             const target = resolveNotifyChannel(issue.labels, project.channels);

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -263,6 +263,10 @@ export class TestProvider implements IssueProvider {
     // no-op in test provider
   }
 
+  async isCommitOnBaseBranch(_issueId: number, _baseBranch: string): Promise<boolean> {
+    return false; // no-op in test provider
+  }
+
   async addComment(issueId: number, body: string): Promise<void> {
     this.calls.push({ method: "addComment", args: { issueId, body } });
     const existing = this.comments.get(issueId) ?? [];


### PR DESCRIPTION
Addresses issue #256

## Problem
Issues stuck in "To Review" when work was committed directly to main (no PR). The review heartbeat only checked for open PRs, so without one it could never transition forward.

## Solution
After `getPrStatus()` returns `CLOSED` with no URL, check git history on the base branch for commits mentioning the issue number. If found, treat as implicitly merged.

## Changes

### `provider.ts`
New interface method: `isCommitOnBaseBranch(issueId, baseBranch): Promise<boolean>`

### `github.ts`
`git log origin/{baseBranch} --oneline -200 --grep '#N'`

### `gitlab.ts`
Same, searches both `#N` (issue) and `!N` (MR reference) patterns

### `review.ts`
- New optional `baseBranch` param on `reviewPass()`
- After `getPrStatus()`: if `!status.url && status.state === CLOSED && baseBranch` → call `isCommitOnBaseBranch()`
- On match: `status.state = MERGED`, audit log `review_git_fallback` event
- Normal transition logic unchanged — falls through to existing MERGED handling

### `heartbeat.ts`
Passes `project.baseBranch` to `reviewPass()`

## Behaviour
- Normal PR flow: unaffected (fallback only runs when no PR URL exists)
- Direct commits: detected, issue advanced to To Test
- False positives: only triggers on explicit `#N` in commit message