### PR TITLE
fix: correct PR-issue linking regex pattern for GitHub provider (#258)

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -160,7 +160,7 @@ export class GitHubProvider implements IssueProvider {
       if (!raw) return [];
       const prs = JSON.parse(raw) as T[];
       const branchPat = new RegExp(`^(?:fix|feat|feature|chore|bugfix|hotfix|refactor|docs|test)/${issueId}-`);
-      const titlePat = new RegExp(`\\b#${issueId}\\b`);
+      const titlePat = new RegExp(`#${issueId}\\b`);
 
       // Primary: match by branch name
       const byBranch = prs.filter((pr) => pr.headRefName && branchPat.test(pr.headRefName));


### PR DESCRIPTION
The previous regex pattern \b#${issueId}\b failed to match issue references because word boundaries (\b) don't work with non-word characters like #.

Changed from:  \b#241\b (matches nothing)
Changed to:    #241\b   (matches correctly)

This allows the provider to properly detect issue references in PR titles and bodies like:
- 'Addresses issue #241'
- 'Fixes #241'
- '#241 is about...'

And correctly rejects partial matches:
- '#2410' (has trailing word char)

The regex now properly links PRs to issues for feedback detection.