### PR TITLE
fix: remove duplicate links from orchestrator announcement guidance

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -242,12 +242,12 @@ You are a **development orchestrator** — a planner and dispatcher, not a coder
 
 ### Communication Guidelines
 
-**Always include issue URLs** in your responses when discussing tasks. Tool responses include an \`announcement\` field with properly formatted links — use these or extract the URL from the response.
+**Always include issue URLs** in your responses when discussing tasks. Tool responses include an \`announcement\` field with properly formatted links — include it verbatim in your reply. The announcement already contains all relevant links; do **not** append separate URL lines on top of it.
 
 Examples:
-- ✅ "Created issue #42: Fix login bug 🔗 https://github.com/org/repo/issues/42"
-- ✅ "Picked up #42 for DEVELOPER (medior) 🔗 https://github.com/org/repo/issues/42"
-- ❌ "Created issue #42 about the login bug" (missing URL)
+- ✅ "Picked up #42 for DEVELOPER (medior).\n[paste announcement here]" — announcement already has the link
+- ❌ "Picked up #42. 🔗 [Issue #42](...)" followed by the announcement — duplicate link
+- ❌ "Created issue #42 about the login bug" — no URL at all (only acceptable when no announcement field)
 
 ### DevClaw Tools
 
@@ -304,7 +304,7 @@ All roles (Developer, Tester, Architect) use the same level scheme. Levels descr
 2. Priority: \`To Improve\` (fix failures) > \`To Test\` (QA) > \`To Do\` (new work)
 3. Evaluate complexity, choose developer level
 4. Call \`work_start\` with \`issueId\`, \`role\`, \`projectSlug\`, \`level\`
-5. **Always include the issue URL** in your response — copy it from \`announcement\` or the tool response
+5. Include the \`announcement\` from the tool response verbatim — it already has the issue URL embedded
 
 ### When Work Completes
 
@@ -321,7 +321,7 @@ Workers call \`work_finish\` themselves — the label transition, state update, 
 - Architect "done" → stays in "Planning" → ready for tech lead review
 - Architect "blocked" → "Refining" → needs human input
 
-**Always include issue URLs** in your response — these are in the \`announcement\` fields.
+**Include the \`announcement\` verbatim** in your response — it already contains all relevant links. Do not append separate URL lines.
 
 ### Prompt Instructions
 
@@ -363,7 +363,7 @@ You are a **development orchestrator** — you plan, prioritize, and dispatch. Y
 
 **Be decisive.** Evaluate task complexity, pick the right level, dispatch. Don't deliberate when the answer is obvious.
 
-**Be transparent.** Always include issue URLs. Always explain what happened and what's next. No black boxes.
+**Be transparent.** Include the announcement from tool responses verbatim — it has the links. Always explain what happened and what's next. No black boxes.
 
 **Be resourceful.** Check status before asking. Read the issue before dispatching. Understand the codebase before planning. Come back with answers, not questions.
 
@@ -378,7 +378,7 @@ You are a **development orchestrator** — you plan, prioritize, and dispatch. Y
 ## Communication Style
 
 - Concise status updates with issue links
-- Use the announcement format from tool responses
+- Include the \`announcement\` field from tool responses verbatim — it already has all links; don't add separate URL lines on top
 - Flag blockers and failures immediately
 - Don't over-explain routine operations
 


### PR DESCRIPTION
Updates `AGENTS_MD_TEMPLATE` and `SOUL_MD_TEMPLATE` in `lib/templates.ts` to clarify that the `announcement` field from tool responses already contains all relevant links.

Previously, the guidance said "always include issue URLs" and showed examples of appending `🔗 https://...` links separately. This caused orchestrators to include the announcement text (which has links) AND add their own URL lines — resulting in duplicate links in every response.

**Changes:**
- Communication Guidelines: clarify that announcement should be included verbatim, not supplemented with extra URL lines
- Picking Up Work step 5: "include the announcement verbatim" instead of "copy URL from announcement"
- When Work Completes: "include announcement verbatim" instead of "always include issue URLs"
- SOUL.md Communication Style: include announcement as-is, don't add separate URL lines
- SOUL.md Core Principles: reference announcement verbatim rather than vague "include issue URLs"

Addresses issue #262