### PR TITLE
fix: remove unreliable GitLab MR approval detection (#265)

### DIFF
--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -247,12 +247,13 @@ export class GitLabProvider implements IssueProvider {
         approvals_left?: number;
         approved_by?: Array<unknown>;
       };
-      // Require at least one explicit approval.  When a project has zero
-      // approval rules, GitLab returns approvals_left:0 even though nobody
-      // has actually reviewed — so approvals_left alone is not trustworthy.
-      if (data.approved === true) return true;
+      // Only trust explicit approvals — ignore bare 'approved' flag.
+      // When a project has zero approval rules, GitLab returns approved:true
+      // even though nobody has actually reviewed, causing false positives.
       const hasExplicitApproval = Array.isArray(data.approved_by) && data.approved_by.length > 0;
-      return hasExplicitApproval && (data.approvals_left ?? 1) === 0;
+      if (!hasExplicitApproval) return false;
+      // All required approvals satisfied
+      return (data.approvals_left ?? 1) <= 0;
     } catch { return false; }
   }
 


### PR DESCRIPTION
Only trust explicit approvals via approved_by array. GitLab returns approved:true by default when a project has no approval rules, causing false positives. Removes bare 'approved' flag check and ensures MRs without actual reviewer approvals stay in 'To Review'.

Fixes: lostpetalarm#61 auto-merging without approvals