### PR TITLE
feat: Update developer prompt template with PR validation checklist (#276)

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -23,11 +23,37 @@ Read the comments carefully — they often contain clarifications, decisions, or
 
 - Work in a git worktree (never switch branches in the main repo)
 - Run tests before completing
-- Create an MR/PR to the base branch
+- Create a PR to the base branch
 - **IMPORTANT:** Do NOT use closing keywords in PR/MR descriptions (no "Closes #X", "Fixes #X", "Resolves #X"). Use "As described in issue #X" or "Addresses issue #X" instead. DevClaw manages issue state — auto-closing bypasses the review lifecycle.
 - **Do NOT merge the PR yourself** — leave it open for review. The system will auto-merge when approved.
 - If you discover unrelated bugs, call task_create to file them
 - Do NOT call work_start, status, health, or project_register
+
+## CRITICAL: Before Calling work_finish
+
+**You MUST create a PR and verify it exists before completing work.**
+
+Checklist before \`work_finish(result="done")\`:
+
+1. ✅ **All changes committed** — run \`git log --oneline -3\` to verify
+2. ✅ **Branch pushed** — run \`git push -u origin <branch-name>\`
+3. ✅ **PR created** — use \`gh pr create --base main --head <your-branch>\`
+4. ✅ **PR verified** — run \`gh pr view\` or \`gh pr list\` to confirm PR number and state
+5. ✅ **PR has issue reference** — description should say "As described in issue #X" (not closing keywords)
+
+**If no PR exists:** The system will reject your work_finish call. Create the PR first.
+
+### Example workflow:
+
+\`\`\`bash
+git log --oneline -3
+git push -u origin feat/my-feature
+gh pr create --base main --head feat/my-feature --title "feat: ..." --body "As described in issue #123"
+gh pr view
+# Then: work_finish(result="done", summary="...", prUrl="https://github.com/.../pull/N")
+\`\`\`
+
+**Why this matters:** Without a PR, the code can't be reviewed, tested, or merged. The system requires a PR to proceed to the next workflow stage.
 `;
 
 export const DEFAULT_QA_INSTRUCTIONS = `# TESTER Worker Instructions


### PR DESCRIPTION
## Summary

Syncs the developer prompt template (used by project_register scaffolding) with the improved runtime prompt that now includes the PR validation checklist.

## Changes

Updated `lib/templates.ts` DEFAULT_DEV_INSTRUCTIONS to include:

1. **'CRITICAL: Before Calling work_finish' section** with:
   - 5-step PR creation checklist (commit, push, create, verify, reference)
   - Concrete bash example workflow: `git push → gh pr create → gh pr view`
   - Clear explanation of why PR is required for workflow progression
   - Warning: system rejects `work_finish` without an open PR

2. **Consistency improvement**: 'Create an MR/PR' → 'Create a PR'

## Impact

- ✅ **New projects** scaffolded by project_register will receive the updated guidance
- ✅ **Existing projects** unaffected (scaffolding is idempotent — never overwrites)
- ✅ **Template matches runtime** — alignment between source and deployed prompts
- ✅ Future developers won't get outdated instructions from new project setup

## How It Works

When `project_register` creates a new project, it reads DEFAULT_DEV_INSTRUCTIONS and scaffolds:
```
<project>/prompts/developer.md
```

This PR updates the source template so all new projects start with the PR validation checklist baked in.

## As described in issue #276