### PR TITLE
fix: Update developer prompt template to forbid self-merge (#278)

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -24,8 +24,10 @@ Read the comments carefully — they often contain clarifications, decisions, or
 - Work in a git worktree (never switch branches in the main repo)
 - Run tests before completing
 - Create an MR/PR to the base branch
+- **CRITICAL: Do NOT merge the PR/MR yourself** — leave it open for review. The system handles all merges after human approval.
+  - Do NOT run \`git push --force\`, \`git merge\`, \`glab mr merge\`, \`gh pr merge\`, etc.
+  - Exception: If you need to force-push your own branch for rebasing, that's OK. But never merge to base.
 - **IMPORTANT:** Do NOT use closing keywords in PR/MR descriptions (no "Closes #X", "Fixes #X", "Resolves #X"). Use "As described in issue #X" or "Addresses issue #X" instead. DevClaw manages issue state — auto-closing bypasses the review lifecycle.
-- **Do NOT merge the PR yourself** — leave it open for review. The system will auto-merge when approved.
 - If you discover unrelated bugs, call task_create to file them
 - Do NOT call work_start, status, health, or project_register
 `;


### PR DESCRIPTION
## Summary

Sync the developer prompt template (used by project_register scaffolding) with the corrected runtime guidance that was updated after the lostpetalarm MR #63 unauthorized merge investigation.

## Root Cause (issue #278)

Developer received conflicting instructions:
- AGENTS.md said: "must merge to base branch"
- developer.md said: "do NOT merge yourself"

Developer followed AGENTS.md, merged the MR, and heartbeat treated the self-merge as "approval" → unauthorized auto-close.

## Changes

Updated `lib/templates.ts` DEFAULT_DEV_INSTRUCTIONS to:
- Clarify 'Do NOT merge' as **CRITICAL** requirement
- Add explicit examples of forbidden commands (`git merge`, `glab mr merge`, `gh pr merge`, etc)
- Document exception: force-push own branch for rebasing is OK, but never merge to base

## Impact

- ✅ New projects scaffolded by project_register inherit correct merge policy
- ✅ No impact on existing projects (scaffolding is idempotent)
- ✅ Ensures consistency between runtime prompts and source templates
- ✅ Prevents future projects from getting outdated guidance

## Related

- **Issue #278:** Investigation of unauthorized merge (completed)
- **AGENTS.md:** Already updated in runtime workspace
- **developer.md:** Already updated in runtime workspace
- **Issue #279:** Code-level self-merge detection and merge guards (in development)

## As described in issue #278