### PR TITLE
feat: add web UI dashboard for mobile monitoring (#268)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import { registerCli } from "./lib/cli.js";
 import { registerHeartbeatService } from "./lib/services/heartbeat.js";
 import { registerBootstrapHook } from "./lib/bootstrap-hook.js";
 import { initRunCommand } from "./lib/run-command.js";
+import { createUiHandler } from "./lib/ui/handler.js";
 
 const plugin = {
   id: "devclaw",
@@ -111,6 +112,9 @@ const plugin = {
 
     // Bootstrap hook for worker instruction injection
     registerBootstrapHook(api);
+
+    // Web UI dashboard at /devclaw-ui/*
+    api.registerHttpHandler(createUiHandler(api));
 
     api.logger.info(
       "DevClaw plugin registered (15 tools, 1 CLI command group, 1 service, 1 hook)",

--- a/lib/ui/api.ts
+++ b/lib/ui/api.ts
@@ -1,0 +1,147 @@
+/**
+ * API endpoints for the DevClaw UI dashboard.
+ * Returns JSON data for the dashboard, session inspector, and diff explorer.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { readProjects, resolveRepoPath } from "../projects.js";
+import { fetchGatewaySessions } from "../services/gateway-sessions.js";
+import { createProvider } from "../providers/index.js";
+import type { Project, WorkerState } from "../projects.js";
+import type { GatewaySession } from "../services/gateway-sessions.js";
+
+export type DashboardProject = {
+  slug: string;
+  name: string;
+  repo: string;
+  baseBranch: string;
+  provider?: string;
+  workers: Record<string, WorkerState & { sessionData?: GatewaySession | null }>;
+};
+
+export type DashboardData = {
+  projects: DashboardProject[];
+  sessions: Record<string, GatewaySession>;
+  queue: { toDo: number; toImprove: number; toReview: number; toTest: number };
+  timestamp: number;
+};
+
+function json(res: ServerResponse, data: unknown, status = 200): void {
+  res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+  res.end(JSON.stringify(data));
+}
+
+function error(res: ServerResponse, msg: string, status = 500): void {
+  json(res, { error: msg }, status);
+}
+
+export async function handleApiRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  workspaceDir: string,
+): Promise<boolean> {
+  if (!pathname.startsWith("/devclaw-ui/api/")) return false;
+
+  const route = pathname.slice("/devclaw-ui/api".length);
+
+  try {
+    if (route === "/status" && req.method === "GET") {
+      return await handleStatus(res, workspaceDir);
+    }
+
+    // /diff/:project/:issueId
+    const diffMatch = route.match(/^\/diff\/([^/]+)\/(\d+)$/);
+    if (diffMatch && req.method === "GET") {
+      return await handleDiff(res, workspaceDir, diffMatch[1], Number(diffMatch[2]));
+    }
+
+    error(res, "Not found", 404);
+    return true;
+  } catch (err) {
+    error(res, (err as Error).message);
+    return true;
+  }
+}
+
+async function handleStatus(res: ServerResponse, workspaceDir: string): Promise<boolean> {
+  const [projectsData, sessionLookup] = await Promise.all([
+    readProjects(workspaceDir),
+    fetchGatewaySessions(),
+  ]);
+
+  const sessions: Record<string, GatewaySession> = {};
+  if (sessionLookup) {
+    for (const [key, sess] of sessionLookup) {
+      sessions[key] = sess;
+    }
+  }
+
+  const queue = { toDo: 0, toImprove: 0, toReview: 0, toTest: 0 };
+  const projects: DashboardProject[] = [];
+
+  for (const [slug, project] of Object.entries(projectsData.projects)) {
+    // Count queue items by querying the provider
+    try {
+      const { provider } = await createProvider({ repo: project.repo, provider: project.provider });
+      const [todoIssues, improveIssues, reviewIssues, testIssues] = await Promise.all([
+        provider.listIssuesByLabel("To Do").catch(() => []),
+        provider.listIssuesByLabel("To Improve").catch(() => []),
+        provider.listIssuesByLabel("To Review").catch(() => []),
+        provider.listIssuesByLabel("To Test").catch(() => []),
+      ]);
+      queue.toDo += todoIssues.length;
+      queue.toImprove += improveIssues.length;
+      queue.toReview += reviewIssues.length;
+      queue.toTest += testIssues.length;
+    } catch {
+      // Provider unavailable — skip queue count
+    }
+
+    const workers: DashboardProject["workers"] = {};
+    for (const [role, worker] of Object.entries(project.workers)) {
+      const sessionKey = worker.level ? worker.sessions[worker.level] : null;
+      workers[role] = {
+        ...worker,
+        sessionData: sessionKey && sessionLookup ? sessionLookup.get(sessionKey) ?? null : null,
+      };
+    }
+
+    projects.push({
+      slug,
+      name: project.name ?? slug,
+      repo: project.repo,
+      baseBranch: project.baseBranch,
+      provider: project.provider,
+      workers,
+    });
+  }
+
+  const data: DashboardData = { projects, sessions, queue, timestamp: Date.now() };
+  json(res, data);
+  return true;
+}
+
+async function handleDiff(
+  res: ServerResponse,
+  workspaceDir: string,
+  projectSlug: string,
+  issueId: number,
+): Promise<boolean> {
+  const projectsData = await readProjects(workspaceDir);
+  const project = projectsData.projects[projectSlug];
+  if (!project) {
+    error(res, `Project not found: ${projectSlug}`, 404);
+    return true;
+  }
+
+  const { provider } = await createProvider({ repo: project.repo, provider: project.provider });
+  const diff = await provider.getPrDiff(issueId);
+
+  if (diff === null) {
+    error(res, `No PR found for issue #${issueId}`, 404);
+    return true;
+  }
+
+  json(res, { diff, issueId, project: projectSlug });
+  return true;
+}

--- a/lib/ui/dashboard.ts
+++ b/lib/ui/dashboard.ts
@@ -1,0 +1,147 @@
+/**
+ * Dashboard page — project cards, worker status, queue summary, token usage.
+ * Mobile-first layout with auto-refresh.
+ */
+import { CSS } from "./styles.js";
+
+export function generateDashboardPage(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DevClaw Dashboard</title>
+  <style>${CSS}</style>
+</head>
+<body>
+  <h1>
+    ⚙️ DevClaw
+    <span class="refresh" id="refresh" title="Auto-refreshing every 5s">⟳ <span id="countdown">5</span>s</span>
+  </h1>
+  <div id="queue-summary"></div>
+  <div id="projects"></div>
+  <div id="sessions-section"></div>
+
+  <script>
+    let refreshInterval = 5000;
+    let countdownTimer;
+    let countdownValue;
+
+    function timeAgo(ts) {
+      if (!ts) return '—';
+      const d = typeof ts === 'string' ? new Date(ts) : new Date(ts);
+      const s = Math.floor((Date.now() - d.getTime()) / 1000);
+      if (s < 60) return s + 's ago';
+      if (s < 3600) return Math.floor(s / 60) + 'm ago';
+      if (s < 86400) return Math.floor(s / 3600) + 'h ago';
+      return Math.floor(s / 86400) + 'd ago';
+    }
+
+    function progressClass(pct) {
+      if (pct < 50) return 'progress-low';
+      if (pct < 80) return 'progress-mid';
+      return 'progress-high';
+    }
+
+    function roleIcon(role) {
+      const icons = { developer: '🔧', tester: '🧪', reviewer: '👀', architect: '🏗️' };
+      return icons[role] || '📋';
+    }
+
+    function renderWorker(role, w) {
+      const active = w.active;
+      const statusBadge = active
+        ? '<span class="badge badge-active">active</span>'
+        : '<span class="badge badge-idle">idle</span>';
+      const roleBadge = '<span class="badge badge-role">' + role.slice(0, 3).toUpperCase() + '</span>';
+      const levelBadge = w.level ? '<span class="badge badge-level">' + w.level + '</span>' : '';
+
+      let detail = '';
+      if (active && w.issueId) {
+        detail += ' <a href="javascript:void(0)" style="color:var(--text)">#' + w.issueId + '</a>';
+        if (w.startTime) detail += ' · ' + timeAgo(w.startTime);
+      }
+
+      let tokenBar = '';
+      if (w.sessionData) {
+        const pct = Math.round(w.sessionData.percentUsed || 0);
+        tokenBar = '<div style="flex:1;max-width:120px"><div class="progress-bar"><div class="progress-fill ' + progressClass(pct) + '" style="width:' + pct + '%"></div></div><div style="font-size:0.7rem;color:var(--text-muted);text-align:right">' + pct + '%</div></div>';
+      }
+
+      const sessionKey = w.level && w.sessions ? w.sessions[w.level] : null;
+      const link = sessionKey ? '/devclaw-ui/session/' + encodeURIComponent(sessionKey) : null;
+
+      return '<div class="worker-row">' +
+        roleIcon(role) + ' ' + roleBadge + ' ' + levelBadge + ' ' + statusBadge + detail +
+        (tokenBar ? '<div style="margin-left:auto;display:flex;align-items:center;gap:8px">' + tokenBar + '</div>' : '') +
+        (link ? '<a href="' + link + '" style="font-size:0.75rem">details →</a>' : '') +
+        '</div>';
+    }
+
+    function renderProject(p) {
+      const roles = Object.entries(p.workers);
+      let html = '<div class="card"><div class="card-title">● ' + (p.name || p.slug) + '</div>';
+      if (roles.length === 0) {
+        html += '<div class="empty">No workers configured</div>';
+      } else {
+        for (const [role, worker] of roles) {
+          html += renderWorker(role, worker);
+        }
+      }
+      html += '</div>';
+      return html;
+    }
+
+    function renderQueue(q) {
+      const items = [];
+      if (q.toImprove > 0) items.push('<span class="queue-item" style="color:var(--orange)">⚠️ <strong>' + q.toImprove + '</strong> To Improve</span>');
+      if (q.toDo > 0) items.push('<span class="queue-item">📋 <strong>' + q.toDo + '</strong> To Do</span>');
+      if (q.toReview > 0) items.push('<span class="queue-item">👀 <strong>' + q.toReview + '</strong> To Review</span>');
+      if (q.toTest > 0) items.push('<span class="queue-item">🧪 <strong>' + q.toTest + '</strong> To Test</span>');
+      if (items.length === 0) return '<div class="queue-summary" style="color:var(--text-muted)">Queue empty</div>';
+      return '<div class="queue-summary">' + items.join('') + '</div>';
+    }
+
+    function renderSessions(sessions) {
+      const entries = Object.entries(sessions);
+      if (entries.length === 0) return '';
+      let html = '<div class="card" style="margin-top:16px"><div class="card-title">📡 Sessions (' + entries.length + ' active)</div><div class="session-list">';
+      for (const [key, s] of entries) {
+        const pct = Math.round(s.percentUsed || 0);
+        html += '<div class="session-item"><a href="/devclaw-ui/session/' + encodeURIComponent(key) + '">' + key + '</a><div style="display:flex;align-items:center;gap:8px"><div class="progress-bar" style="width:80px"><div class="progress-fill ' + progressClass(pct) + '" style="width:' + pct + '%"></div></div><span style="font-size:0.75rem;color:var(--text-muted)">' + pct + '%</span></div></div>';
+      }
+      html += '</div></div>';
+      return html;
+    }
+
+    function startCountdown() {
+      countdownValue = refreshInterval / 1000;
+      document.getElementById('countdown').textContent = countdownValue;
+      clearInterval(countdownTimer);
+      countdownTimer = setInterval(() => {
+        countdownValue--;
+        if (countdownValue <= 0) countdownValue = refreshInterval / 1000;
+        document.getElementById('countdown').textContent = countdownValue;
+      }, 1000);
+    }
+
+    async function fetchAndRender() {
+      try {
+        const res = await fetch('/devclaw-ui/api/status');
+        const data = await res.json();
+        document.getElementById('queue-summary').innerHTML = renderQueue(data.queue);
+        document.getElementById('projects').innerHTML = data.projects.map(renderProject).join('');
+        document.getElementById('sessions-section').innerHTML = renderSessions(data.sessions);
+      } catch (e) {
+        document.getElementById('projects').innerHTML = '<div class="error-msg">Failed to load: ' + e.message + '</div>';
+      }
+      startCountdown();
+    }
+
+    fetchAndRender();
+    setInterval(fetchAndRender, refreshInterval);
+    document.getElementById('refresh').addEventListener('click', fetchAndRender);
+  </script>
+</body>
+</html>`;
+}

--- a/lib/ui/diff.ts
+++ b/lib/ui/diff.ts
@@ -1,0 +1,152 @@
+/**
+ * Git Diff Explorer page — file tree + diff2html rendering.
+ */
+import { CSS } from "./styles.js";
+
+export function generateDiffPage(projectSlug: string, issueId: number): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diff: ${escapeHtml(projectSlug)} #${issueId}</title>
+  <style>${CSS}</style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html@3.4.48/bundles/css/diff2html.min.css">
+</head>
+<body>
+  <a href="/devclaw-ui/" class="back">← Dashboard</a>
+  <h1>📄 Diff: ${escapeHtml(projectSlug)} #${issueId}</h1>
+
+  <div class="toggle-group" id="view-toggle">
+    <button class="active" data-view="side-by-side">Split</button>
+    <button data-view="line-by-line">Unified</button>
+  </div>
+
+  <div id="content"><div class="empty">Loading diff...</div></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/diff2html@3.4.48/bundles/js/diff2html-ui.min.js"></script>
+  <script>
+    const projectSlug = ${JSON.stringify(projectSlug)};
+    const issueId = ${issueId};
+    let rawDiff = '';
+    let currentView = 'side-by-side';
+
+    function parseDiffFiles(diff) {
+      const files = [];
+      const parts = diff.split(/^diff --git /m).filter(Boolean);
+      for (const part of parts) {
+        const nameMatch = part.match(/^a\\/(.+?)\\s/);
+        const adds = (part.match(/^\\+[^+]/gm) || []).length;
+        const dels = (part.match(/^-[^-]/gm) || []).length;
+        if (nameMatch) files.push({ name: nameMatch[1], additions: adds, deletions: dels });
+      }
+      return files;
+    }
+
+    function renderFileTree(files) {
+      const totalAdd = files.reduce((s, f) => s + f.additions, 0);
+      const totalDel = files.reduce((s, f) => s + f.deletions, 0);
+
+      let html = '<div class="diff-stats">' + files.length + ' file' + (files.length !== 1 ? 's' : '') +
+        ' · <span class="add">+' + totalAdd + '</span> <span class="del">-' + totalDel + '</span></div>';
+
+      // Mobile dropdown
+      html += '<select class="file-select" id="file-select"><option value="">All files</option>';
+      files.forEach((f, i) => {
+        html += '<option value="' + i + '">' + f.name + ' (+' + f.additions + ' -' + f.deletions + ')</option>';
+      });
+      html += '</select>';
+
+      // Desktop tree
+      html += '<div class="file-tree">';
+      files.forEach((f, i) => {
+        html += '<div class="file-tree-item" data-idx="' + i + '">' +
+          '📄 <span style="flex:1">' + f.name + '</span>' +
+          '<span class="additions">+' + f.additions + '</span>' +
+          '<span class="deletions">-' + f.deletions + '</span></div>';
+      });
+      html += '</div>';
+      return html;
+    }
+
+    function renderDiff(view) {
+      if (!rawDiff) return;
+      const files = parseDiffFiles(rawDiff);
+      const fileTreeHtml = renderFileTree(files);
+
+      const diffEl = document.createElement('div');
+      diffEl.id = 'diff-output';
+
+      document.getElementById('content').innerHTML =
+        '<div class="diff-layout">' +
+        '<div>' + fileTreeHtml + '</div>' +
+        '<div id="diff-container"></div>' +
+        '</div>';
+
+      const container = document.getElementById('diff-container');
+      container.appendChild(diffEl);
+
+      const diff2htmlUi = new Diff2HtmlUI(diffEl, rawDiff, {
+        drawFileList: false,
+        matching: 'lines',
+        outputFormat: view,
+        highlight: true,
+      });
+      diff2htmlUi.draw();
+      diff2htmlUi.highlightCode();
+
+      // File click → scroll to file
+      document.querySelectorAll('.file-tree-item').forEach(el => {
+        el.addEventListener('click', () => {
+          const idx = parseInt(el.dataset.idx);
+          const headers = diffEl.querySelectorAll('.d2h-file-wrapper');
+          if (headers[idx]) headers[idx].scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+      });
+      const sel = document.getElementById('file-select');
+      if (sel) {
+        sel.addEventListener('change', () => {
+          const idx = parseInt(sel.value);
+          if (!isNaN(idx)) {
+            const headers = diffEl.querySelectorAll('.d2h-file-wrapper');
+            if (headers[idx]) headers[idx].scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        });
+      }
+    }
+
+    // View toggle
+    document.getElementById('view-toggle').addEventListener('click', (e) => {
+      const btn = e.target.closest('button');
+      if (!btn) return;
+      document.querySelectorAll('#view-toggle button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      currentView = btn.dataset.view;
+      renderDiff(currentView);
+    });
+
+    async function load() {
+      try {
+        const res = await fetch('/devclaw-ui/api/diff/' + projectSlug + '/' + issueId);
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: 'Request failed' }));
+          document.getElementById('content').innerHTML = '<div class="error-msg">' + (err.error || 'Failed to load diff') + '</div>';
+          return;
+        }
+        const data = await res.json();
+        rawDiff = data.diff;
+        renderDiff(currentView);
+      } catch (e) {
+        document.getElementById('content').innerHTML = '<div class="error-msg">Failed to load: ' + e.message + '</div>';
+      }
+    }
+
+    load();
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/lib/ui/handler.ts
+++ b/lib/ui/handler.ts
@@ -1,0 +1,72 @@
+/**
+ * HTTP handler for DevClaw UI dashboard.
+ * Routes /devclaw-ui/* requests to the appropriate page or API endpoint.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { generateDashboardPage } from "./dashboard.js";
+import { generateSessionPage } from "./session.js";
+import { generateDiffPage } from "./diff.js";
+import { handleApiRequest } from "./api.js";
+
+function html(res: ServerResponse, body: string, status = 200): void {
+  res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(body);
+}
+
+/**
+ * Resolve workspace directory from the plugin API config.
+ * Uses the same discovery logic as the heartbeat service.
+ */
+function resolveWorkspaceDir(api: any): string {
+  // Try explicit agent list first
+  const agents = api.config?.agents?.list || [];
+  for (const a of agents) {
+    if (a.workspace) return a.workspace;
+  }
+  // Try default workspace
+  if (api.config?.agents?.defaults?.workspace) {
+    return api.config.agents.defaults.workspace;
+  }
+  // Fallback
+  return process.env.OPENCLAW_WORKSPACE ?? process.cwd();
+}
+
+export function createUiHandler(api: any) {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const url = new URL(req.url || "/", `http://${req.headers.host}`);
+    const pathname = url.pathname;
+
+    if (!pathname.startsWith("/devclaw-ui")) return false;
+
+    const workspaceDir = resolveWorkspaceDir(api);
+
+    // API routes
+    if (pathname.startsWith("/devclaw-ui/api/")) {
+      return handleApiRequest(req, res, pathname, workspaceDir);
+    }
+
+    // Dashboard
+    if (pathname === "/devclaw-ui" || pathname === "/devclaw-ui/") {
+      html(res, generateDashboardPage());
+      return true;
+    }
+
+    // Session inspector: /devclaw-ui/session/:key
+    const sessionMatch = pathname.match(/^\/devclaw-ui\/session\/(.+)$/);
+    if (sessionMatch) {
+      html(res, generateSessionPage(decodeURIComponent(sessionMatch[1])));
+      return true;
+    }
+
+    // Diff explorer: /devclaw-ui/diff/:project/:issueId
+    const diffMatch = pathname.match(/^\/devclaw-ui\/diff\/([^/]+)\/(\d+)$/);
+    if (diffMatch) {
+      html(res, generateDiffPage(diffMatch[1], Number(diffMatch[2])));
+      return true;
+    }
+
+    // 404
+    html(res, `<!DOCTYPE html><html><body style="background:#0d1117;color:#e6edf3;font-family:sans-serif;padding:40px;text-align:center"><h1>404</h1><p>Page not found</p><a href="/devclaw-ui/" style="color:#58a6ff">← Dashboard</a></body></html>`, 404);
+    return true;
+  };
+}

--- a/lib/ui/session.ts
+++ b/lib/ui/session.ts
@@ -1,0 +1,106 @@
+/**
+ * Session Inspector page — token usage, context progress, issue/PR links.
+ */
+import { CSS } from "./styles.js";
+
+export function generateSessionPage(sessionKey: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Session: ${escapeHtml(sessionKey)}</title>
+  <style>${CSS}</style>
+</head>
+<body>
+  <a href="/devclaw-ui/" class="back">← Dashboard</a>
+  <h1>📡 Session Inspector</h1>
+  <div id="content"><div class="empty">Loading...</div></div>
+
+  <script>
+    const sessionKey = ${JSON.stringify(sessionKey)};
+
+    function timeAgo(ts) {
+      if (!ts) return '—';
+      const d = typeof ts === 'string' ? new Date(ts) : new Date(ts);
+      const s = Math.floor((Date.now() - d.getTime()) / 1000);
+      if (s < 60) return s + 's ago';
+      if (s < 3600) return Math.floor(s / 60) + 'm ago';
+      if (s < 86400) return Math.floor(s / 3600) + 'h ago';
+      return Math.floor(s / 86400) + 'd ago';
+    }
+
+    function progressClass(pct) {
+      if (pct < 50) return 'progress-low';
+      if (pct < 80) return 'progress-mid';
+      return 'progress-high';
+    }
+
+    async function load() {
+      try {
+        const res = await fetch('/devclaw-ui/api/status');
+        const data = await res.json();
+
+        const session = data.sessions[sessionKey];
+
+        // Find the worker that uses this session
+        let workerInfo = null;
+        for (const p of data.projects) {
+          for (const [role, w] of Object.entries(p.workers)) {
+            const sk = w.level && w.sessions ? w.sessions[w.level] : null;
+            if (sk === sessionKey) {
+              workerInfo = { project: p, role, worker: w };
+              break;
+            }
+          }
+          if (workerInfo) break;
+        }
+
+        let html = '<div class="card"><div class="card-title">' + sessionKey + '</div>';
+
+        if (workerInfo) {
+          const w = workerInfo.worker;
+          html += '<div class="stat"><span class="stat-label">Project</span><span>' + workerInfo.project.name + '</span></div>';
+          html += '<div class="stat"><span class="stat-label">Role</span><span>' + workerInfo.role.toUpperCase() + '</span></div>';
+          if (w.level) html += '<div class="stat"><span class="stat-label">Level</span><span>' + w.level + '</span></div>';
+          if (w.issueId) html += '<div class="stat"><span class="stat-label">Issue</span><span>#' + w.issueId + '</span></div>';
+          html += '<div class="stat"><span class="stat-label">Status</span><span>' + (w.active ? '<span class="badge badge-active">active</span>' : '<span class="badge badge-idle">idle</span>') + '</span></div>';
+          if (w.startTime) html += '<div class="stat"><span class="stat-label">Started</span><span>' + timeAgo(w.startTime) + '</span></div>';
+        }
+        html += '</div>';
+
+        if (session) {
+          const pct = Math.round(session.percentUsed || 0);
+          html += '<div class="card"><div class="card-title">Context Usage</div>';
+          html += '<div class="progress-bar" style="height:16px;margin:8px 0"><div class="progress-fill ' + progressClass(pct) + '" style="width:' + pct + '%"></div></div>';
+          html += '<div style="text-align:center;font-size:1.2rem;font-weight:600;margin:8px 0">' + pct + '%</div>';
+          if (session.updatedAt) html += '<div class="stat"><span class="stat-label">Last updated</span><span>' + timeAgo(session.updatedAt) + '</span></div>';
+          if (session.abortedLastRun) html += '<div style="margin-top:8px;color:var(--orange)">⚠️ Last run was aborted</div>';
+          html += '</div>';
+        } else {
+          html += '<div class="card"><div class="empty">No gateway session data available for this key</div></div>';
+        }
+
+        // Diff link if worker has an active issue
+        if (workerInfo && workerInfo.worker.issueId) {
+          html += '<div style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap">';
+          html += '<a href="/devclaw-ui/diff/' + workerInfo.project.slug + '/' + workerInfo.worker.issueId + '" class="btn">📄 View Diff</a>';
+          html += '</div>';
+        }
+
+        document.getElementById('content').innerHTML = html;
+      } catch (e) {
+        document.getElementById('content').innerHTML = '<div class="error-msg">Failed to load: ' + e.message + '</div>';
+      }
+    }
+
+    load();
+    setInterval(load, 10000);
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/lib/ui/styles.ts
+++ b/lib/ui/styles.ts
@@ -1,0 +1,251 @@
+/**
+ * Shared CSS styles for the DevClaw UI dashboard.
+ * Mobile-first, dark theme matching the gateway aesthetic.
+ */
+
+export const CSS = `
+  :root {
+    --bg: #0d1117;
+    --bg-card: #161b22;
+    --bg-hover: #1c2129;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --accent: #58a6ff;
+    --green: #3fb950;
+    --red: #f85149;
+    --orange: #d29922;
+    --purple: #bc8cff;
+    --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    --mono: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+    padding: 16px;
+    max-width: 960px;
+    margin: 0 auto;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  h1 {
+    font-size: 1.4rem;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  h1 .refresh {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+  }
+  h1 .refresh:hover { color: var(--accent); }
+
+  .back { display: inline-block; margin-bottom: 12px; font-size: 0.9rem; }
+
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 12px;
+  }
+
+  .card-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .worker-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 0;
+    font-size: 0.9rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .worker-row:last-child { border-bottom: none; }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .badge-active { background: rgba(63, 185, 80, 0.15); color: var(--green); }
+  .badge-idle { background: rgba(139, 148, 158, 0.15); color: var(--text-muted); }
+  .badge-role { background: rgba(88, 166, 255, 0.15); color: var(--accent); }
+  .badge-level { background: rgba(188, 140, 255, 0.15); color: var(--purple); }
+
+  .progress-bar {
+    width: 100%;
+    height: 8px;
+    background: var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 4px 0;
+  }
+  .progress-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s;
+  }
+  .progress-low { background: var(--green); }
+  .progress-mid { background: var(--orange); }
+  .progress-high { background: var(--red); }
+
+  .stat { display: flex; justify-content: space-between; padding: 4px 0; font-size: 0.85rem; }
+  .stat-label { color: var(--text-muted); }
+
+  .queue-summary {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+    font-size: 0.85rem;
+  }
+  .queue-item { color: var(--text-muted); }
+  .queue-item strong { color: var(--text); }
+
+  .session-list .session-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+  }
+  .session-item:last-child { border-bottom: none; }
+
+  .btn {
+    display: inline-block;
+    padding: 6px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-card);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  .btn:hover { background: var(--bg-hover); border-color: var(--accent); }
+  .btn-danger { border-color: var(--red); color: var(--red); }
+  .btn-danger:hover { background: rgba(248, 81, 73, 0.1); }
+
+  .toggle-group {
+    display: flex;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    margin-bottom: 12px;
+  }
+  .toggle-group button {
+    flex: 1;
+    padding: 6px 12px;
+    border: none;
+    background: var(--bg-card);
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  .toggle-group button.active {
+    background: var(--accent);
+    color: #fff;
+  }
+
+  .file-tree {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-card);
+    overflow: hidden;
+    margin-bottom: 12px;
+  }
+  .file-tree-item {
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-family: var(--mono);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .file-tree-item:last-child { border-bottom: none; }
+  .file-tree-item:hover { background: var(--bg-hover); }
+  .file-tree-item.active { background: rgba(88, 166, 255, 0.1); color: var(--accent); }
+  .file-tree-item .additions { color: var(--green); font-size: 0.75rem; }
+  .file-tree-item .deletions { color: var(--red); font-size: 0.75rem; }
+
+  .diff-stats {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+  }
+  .diff-stats .add { color: var(--green); }
+  .diff-stats .del { color: var(--red); }
+
+  /* Dropdown file selector for mobile */
+  .file-select {
+    width: 100%;
+    padding: 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    margin-bottom: 12px;
+  }
+
+  /* Desktop: side by side layout */
+  @media (min-width: 768px) {
+    .diff-layout {
+      display: grid;
+      grid-template-columns: 240px 1fr;
+      gap: 12px;
+    }
+    .file-select { display: none; }
+  }
+  @media (max-width: 767px) {
+    .file-tree { display: none; }
+  }
+
+  .empty { color: var(--text-muted); font-style: italic; padding: 12px 0; }
+
+  .error-msg {
+    background: rgba(248, 81, 73, 0.1);
+    border: 1px solid var(--red);
+    border-radius: 6px;
+    padding: 12px;
+    color: var(--red);
+  }
+
+  /* diff2html overrides for dark theme */
+  .d2h-wrapper { font-family: var(--mono); font-size: 0.8rem; }
+  .d2h-file-header { background: var(--bg-card) !important; color: var(--text) !important; border-color: var(--border) !important; }
+  .d2h-file-wrapper { border-color: var(--border) !important; margin-bottom: 12px; }
+  .d2h-code-linenumber { background: var(--bg) !important; color: var(--text-muted) !important; border-color: var(--border) !important; }
+  .d2h-code-line { background: var(--bg) !important; color: var(--text) !important; }
+  .d2h-ins { background: rgba(63, 185, 80, 0.1) !important; }
+  .d2h-del { background: rgba(248, 81, 73, 0.1) !important; }
+  .d2h-ins .d2h-code-line-ctn { background: transparent !important; }
+  .d2h-del .d2h-code-line-ctn { background: transparent !important; }
+  .d2h-info { background: rgba(88, 166, 255, 0.1) !important; color: var(--accent) !important; }
+  .d2h-tag { display: none !important; }
+`;


### PR DESCRIPTION
## Summary

Adds a visual web dashboard to DevClaw accessible at `/devclaw-ui/` on the gateway port, for monitoring workers, inspecting sessions, and reviewing code diffs from mobile.

### Pages

1. **Dashboard** (`/devclaw-ui/`) — Project cards with worker status, queue summary, session token usage. Auto-refreshes every 5s.
2. **Session Inspector** (`/devclaw-ui/session/:key`) — Token/context usage visualization, worker details, issue links. Auto-refreshes every 10s.
3. **Git Diff Explorer** (`/devclaw-ui/diff/:project/:issueId`) — PR diff rendering via diff2html with file tree navigation, split/unified toggle.

### API Endpoints

- `GET /devclaw-ui/api/status` — Aggregated dashboard data (projects, workers, sessions, queue counts)
- `GET /devclaw-ui/api/diff/:project/:issueId` — PR diff for an issue

### Technical Details

- Vanilla HTML/CSS/JS — no build step, same pattern as openclaw-better-gateway
- Mobile-first responsive design with dark theme
- Registered via `api.registerHttpHandler()` in plugin registration
- Uses existing data sources: gateway sessions, projects.json, GitHub API
- diff2html loaded from CDN for GitHub-quality diff rendering

As described in issue #268