### PR TITLE
fix: detect COMMENTED PR reviews in review scanner (#296)

### DIFF
--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -374,6 +374,11 @@ export class GitLabProvider implements IssueProvider {
     } catch { /* best-effort */ }
   }
 
+  async reactToPrReview(issueId: number, reviewId: number, emoji: string): Promise<void> {
+    // GitLab doesn't distinguish reviews from comments — use the same note reaction API
+    await this.reactToPrComment(issueId, reviewId, emoji);
+  }
+
   async editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue> {
     const args = ["issue", "update", String(issueId)];
     if (updates.title !== undefined) args.push("--title", updates.title);

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -105,6 +105,11 @@ export interface IssueProvider {
    * @param emoji  Reaction name understood by the provider (e.g. "rocket", "+1")
    */
   reactToPrComment(issueId: number, commentId: number, emoji: string): Promise<void>;
+  /**
+   * Add an emoji reaction to a PR review (not a comment) by its review ID.
+   * Best-effort — implementations should not throw.
+   */
+  reactToPrReview(issueId: number, reviewId: number, emoji: string): Promise<void>;
   addComment(issueId: number, body: string): Promise<void>;
   editIssue(issueId: number, updates: { title?: string; body?: string }): Promise<Issue>;
   healthCheck(): Promise<boolean>;

--- a/lib/services/review.ts
+++ b/lib/services/review.ts
@@ -232,6 +232,12 @@ async function reactToFeedbackComments(
 ): Promise<void> {
   const comments = await provider.getPrReviewComments(issueId);
   for (const comment of comments) {
-    await provider.reactToPrComment(issueId, comment.id, FEEDBACK_REACTION_EMOJI);
+    // Reviews (APPROVED, CHANGES_REQUESTED, COMMENTED) use a different reaction API
+    // than issue/inline comments. Route accordingly.
+    if (comment.state === "APPROVED" || comment.state === "CHANGES_REQUESTED" || comment.state === "COMMENTED") {
+      await provider.reactToPrReview(issueId, comment.id, FEEDBACK_REACTION_EMOJI);
+    } else {
+      await provider.reactToPrComment(issueId, comment.id, FEEDBACK_REACTION_EMOJI);
+    }
   }
 }

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -273,6 +273,10 @@ export class TestProvider implements IssueProvider {
     // no-op in test provider
   }
 
+  async reactToPrReview(_issueId: number, _reviewId: number, _emoji: string): Promise<void> {
+    // no-op in test provider
+  }
+
   async isCommitOnBaseBranch(_issueId: number, _baseBranch: string): Promise<boolean> {
     return false; // no-op in test provider
   }


### PR DESCRIPTION
## Summary

Fixes the PR comment scanner not detecting `COMMENTED` reviews — the most common way reviewers leave feedback on GitHub without formally selecting "Request changes".

### Root Cause

`getPrStatus()` checked for `CHANGES_REQUESTED` reviews and top-level conversation comments, but completely ignored `COMMENTED` reviews. When a reviewer submits feedback as "Comment" (not "Request changes"), the review was invisible to DevClaw.

### Fix

Added `hasUnacknowledgedReviews()` method that:
1. Fetches PR reviews via `/pulls/{pr}/reviews` API
2. Filters for `COMMENTED` state with non-empty body, non-author, non-bot
3. Checks each review for 👀 reaction (acknowledged = already processed)
4. Returns true if any unacknowledged COMMENTED reviews exist

Integrated into `getPrStatus()` flow:
```
CHANGES_REQUESTED? → yes → PrState.CHANGES_REQUESTED
                   → no  → COMMENTED reviews? → yes → PrState.HAS_COMMENTS  ← NEW
                                               → no  → conversation comments? → ...
```

### Additional Changes

- Added `reactToPrReview()` to `IssueProvider` interface — PR review reactions use a different API endpoint (`/pulls/{pr}/reviews/{id}/reactions`) than issue comment reactions
- Updated `reactToFeedbackComments()` in `review.ts` to route review-level vs comment-level reactions correctly
- Added GitLab stub and TestProvider implementation

### Test Case

Issue #283 has PR #292 with a `COMMENTED` review from `laurentenhoor`. After this fix, the heartbeat should detect it and transition #283 to "To Improve".

As described in issue #296