### PR TITLE
fix: getPrStatus returns closed PR url to distinguish closed-PR from no-PR (#315)

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -309,6 +309,13 @@ export class GitHubProvider implements IssueProvider {
       const state = pr.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED;
       return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName };
     }
+    // Check for closed-without-merge PRs. url: non-null = PR was explicitly closed;
+    // url: null = no PR has ever been created for this issue.
+    const allPrs = await this.findPrsViaTimeline(issueId, "all");
+    const closedPr = allPrs?.find((pr) => pr.state === "CLOSED");
+    if (closedPr) {
+      return { state: PrState.CLOSED, url: closedPr.url, title: closedPr.title, sourceBranch: closedPr.headRefName };
+    }
     return { state: PrState.CLOSED, url: null };
   }
 

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -202,6 +202,10 @@ export class GitLabProvider implements IssueProvider {
     // Check merged MRs
     const merged = mrs.find((mr) => mr.state === "merged");
     if (merged) return { state: PrState.MERGED, url: merged.web_url, title: merged.title, sourceBranch: merged.source_branch };
+    // Check for closed-without-merge MRs. url: non-null = MR was explicitly closed;
+    // url: null = no MR has ever been created for this issue.
+    const closed = mrs.find((mr) => mr.state === "closed");
+    if (closed) return { state: PrState.CLOSED, url: closed.web_url, title: closed.title, sourceBranch: closed.source_branch };
     return { state: PrState.CLOSED, url: null };
   }
 

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for getPrStatus() — distinguishing closed-PR from no-PR-exists.
+ *
+ * Issue #315: getPrStatus must return a non-null url for explicitly closed PRs
+ * so callers can distinguish "PR was closed without merging" vs "no PR exists".
+ *
+ * Run with: npx tsx --test lib/providers/provider-pr-status.test.ts
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+import { GitHubProvider } from "./github.js";
+import { GitLabProvider } from "./gitlab.js";
+import { PrState } from "./provider.js";
+
+// ---------------------------------------------------------------------------
+// GitHub provider tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubProvider.getPrStatus — closed PR handling", () => {
+  it("returns url:null when no PR has ever been created", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake" });
+
+    // findPrsForIssue returns [] for open and merged, findPrsViaTimeline returns null (GraphQL unavailable)
+    (provider as any).findPrsForIssue = async () => [];
+    (provider as any).findPrsViaTimeline = async () => null;
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.CLOSED);
+    assert.strictEqual(status.url, null, "no PR exists → url must be null");
+  });
+
+  it("returns url:null when timeline returns empty array (no PRs at all)", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake" });
+
+    (provider as any).findPrsForIssue = async () => [];
+    (provider as any).findPrsViaTimeline = async () => [];
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.CLOSED);
+    assert.strictEqual(status.url, null, "empty timeline → url must be null");
+  });
+
+  it("returns url:closedPrUrl when a closed-without-merge PR exists", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake" });
+
+    const closedPrUrl = "https://github.com/owner/repo/pull/7";
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open" || state === "merged") return [];
+      return [];
+    };
+    (provider as any).findPrsViaTimeline = async (_id: number, state: string) => {
+      if (state === "all") {
+        return [
+          {
+            number: 7,
+            title: "feat: some work",
+            body: "",
+            headRefName: "feature/7-some-work",
+            url: closedPrUrl,
+            mergedAt: null,
+            reviewDecision: null,
+            state: "CLOSED",
+          },
+        ];
+      }
+      return [];
+    };
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.CLOSED);
+    assert.strictEqual(status.url, closedPrUrl, "closed PR → url must be the closed PR url");
+    assert.strictEqual(status.sourceBranch, "feature/7-some-work");
+  });
+
+  it("prefers open PR over closed PR", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake" });
+
+    const openPrUrl = "https://github.com/owner/repo/pull/9";
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") {
+        return [
+          {
+            title: "feat: open pr",
+            body: "",
+            headRefName: "feature/9-open-pr",
+            url: openPrUrl,
+            number: 9,
+            reviewDecision: "",
+            mergeable: "MERGEABLE",
+          },
+        ];
+      }
+      return [];
+    };
+    // Simulate no changes-requested reviews and no comments
+    (provider as any).hasChangesRequestedReview = async () => false;
+    (provider as any).hasUnacknowledgedReviews = async () => false;
+    (provider as any).hasConversationComments = async () => false;
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.OPEN);
+    assert.strictEqual(status.url, openPrUrl);
+  });
+
+  it("prefers merged PR over closed PR", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake" });
+
+    const mergedPrUrl = "https://github.com/owner/repo/pull/5";
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") return [];
+      if (state === "merged") {
+        return [
+          {
+            title: "feat: merged",
+            body: "",
+            headRefName: "feature/5-merged",
+            url: mergedPrUrl,
+            reviewDecision: null,
+          },
+        ];
+      }
+      return [];
+    };
+    (provider as any).findPrsViaTimeline = async () => null;
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.MERGED);
+    assert.strictEqual(status.url, mergedPrUrl);
+  });
+
+  it("ignores non-CLOSED states in timeline when returning closed PR", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake" });
+
+    (provider as any).findPrsForIssue = async () => [];
+    // Timeline has only OPEN PRs — none should trigger closed-PR path
+    (provider as any).findPrsViaTimeline = async (_id: number, state: string) => {
+      if (state === "all") {
+        return [{ number: 10, title: "", body: "", headRefName: "", url: "https://github.com/owner/repo/pull/10", mergedAt: null, reviewDecision: null, state: "OPEN" }];
+      }
+      return [];
+    };
+
+    const status = await provider.getPrStatus(42);
+
+    // OPEN PR in timeline but findPrsForIssue("open") returned [] → shouldn't reach here normally,
+    // but the CLOSED fallback path should not pick it up.
+    assert.strictEqual(status.state, PrState.CLOSED);
+    assert.strictEqual(status.url, null, "OPEN state in timeline should not match closed-PR path");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitLab provider tests
+// ---------------------------------------------------------------------------
+
+describe("GitLabProvider.getPrStatus — closed MR handling", () => {
+  it("returns url:null when no MR has ever been created", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake" });
+
+    (provider as any).getRelatedMRs = async () => [];
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.CLOSED);
+    assert.strictEqual(status.url, null, "no MR exists → url must be null");
+  });
+
+  it("returns url:closedMrUrl when a closed-without-merge MR exists", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake" });
+
+    const closedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/3";
+
+    (provider as any).getRelatedMRs = async () => [
+      {
+        iid: 3,
+        title: "feat: some work",
+        description: "",
+        web_url: closedMrUrl,
+        state: "closed",
+        source_branch: "feature/3-some-work",
+        merged_at: null,
+      },
+    ];
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.CLOSED);
+    assert.strictEqual(status.url, closedMrUrl, "closed MR → url must be the closed MR url");
+    assert.strictEqual(status.sourceBranch, "feature/3-some-work");
+  });
+
+  it("prefers open MR over closed MR", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake" });
+
+    const openMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/4";
+    const closedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/2";
+
+    (provider as any).getRelatedMRs = async () => [
+      { iid: 4, title: "open MR", description: "", web_url: openMrUrl, state: "opened", source_branch: "feature/4", merged_at: null },
+      { iid: 2, title: "closed MR", description: "", web_url: closedMrUrl, state: "closed", source_branch: "feature/2", merged_at: null },
+    ];
+    (provider as any).isMrApproved = async () => false;
+    (provider as any).hasUnresolvedDiscussions = async () => false;
+    (provider as any).hasConversationComments = async () => false;
+    (provider as any).isMrMergeable = async () => true;
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.OPEN);
+    assert.strictEqual(status.url, openMrUrl);
+  });
+
+  it("prefers merged MR over closed MR", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake" });
+
+    const mergedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/5";
+    const closedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/1";
+
+    (provider as any).getRelatedMRs = async () => [
+      { iid: 5, title: "merged", description: "", web_url: mergedMrUrl, state: "merged", source_branch: "feature/5", merged_at: "2026-01-01T00:00:00Z" },
+      { iid: 1, title: "closed", description: "", web_url: closedMrUrl, state: "closed", source_branch: "feature/1", merged_at: null },
+    ];
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.MERGED);
+    assert.strictEqual(status.url, mergedMrUrl);
+  });
+
+  it("handles multiple closed MRs — returns the first found", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake" });
+
+    const closedMrUrl1 = "https://gitlab.com/owner/repo/-/merge_requests/10";
+    const closedMrUrl2 = "https://gitlab.com/owner/repo/-/merge_requests/11";
+
+    (provider as any).getRelatedMRs = async () => [
+      { iid: 10, title: "closed 1", description: "", web_url: closedMrUrl1, state: "closed", source_branch: "feature/10", merged_at: null },
+      { iid: 11, title: "closed 2", description: "", web_url: closedMrUrl2, state: "closed", source_branch: "feature/11", merged_at: null },
+    ];
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.CLOSED);
+    // First closed MR found is returned
+    assert.strictEqual(status.url, closedMrUrl1);
+  });
+});


### PR DESCRIPTION
Addresses issue #315

## Problem

`getPrStatus()` returned `{ state: PrState.CLOSED, url: null }` for both:
- A PR that was explicitly closed without merging
- No PR was ever created for the issue

These must be distinguishable so the heartbeat's `reviewPass` can handle a closed PR (auto-transition to `toImprove`) vs no-PR-yet (do nothing).

## Solution

**Semantics after this fix:**
- `PrState.CLOSED` + `url: null` → no PR/MR has ever been linked to this issue
- `PrState.CLOSED` + `url: <url>` → a PR/MR was explicitly closed without merging

### GitHub (`lib/providers/github.ts`)

After checking open and merged PRs, calls `findPrsViaTimeline(issueId, 'all')` and looks for a PR with `state === 'CLOSED'` (GitHub GraphQL uses uppercase). Returns the closed PR's url when found.

### GitLab (`lib/providers/gitlab.ts`)

`getRelatedMRs()` already returns all related MRs. After the merged check, finds MRs with `state === 'closed'` (GitLab uses lowercase). Returns the closed MR's `web_url` when found.

## Tests

Added `lib/providers/provider-pr-status.test.ts` with 11 tests covering:
- GitHub: null url when no PR, null url when empty timeline, non-null url for closed PR, priority ordering (open > merged > closed), correct state filtering
- GitLab: null url when no MR, non-null url for closed MR, priority ordering (open > merged > closed), multiple closed MRs

All 11 tests pass.