### PR TITLE
feat: handle PR_CLOSED event in reviewPass — auto-transition to toImprove (#316)

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -73,6 +73,14 @@ export type NotifyEvent =
       issueUrl: string;
       issueTitle: string;
       prUrl?: string;
+    }
+  | {
+      type: "prClosed";
+      project: string;
+      issueId: number;
+      issueUrl: string;
+      issueTitle: string;
+      prUrl?: string;
     };
 
 /**
@@ -186,6 +194,14 @@ function buildMessage(event: NotifyEvent): string {
       if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
       msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       msg += `\n→ Moving to To Improve — developer will rebase and resolve`;
+      return msg;
+    }
+
+    case "prClosed": {
+      let msg = `🚫 PR closed without merging for #${event.issueId}: ${event.issueTitle}`;
+      if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
+      msg += `\n→ Moving to To Improve for developer attention`;
       return msg;
     }
   }

--- a/lib/services/heartbeat.ts
+++ b/lib/services/heartbeat.ts
@@ -377,6 +377,26 @@ export async function tick(opts: {
             },
           ).catch(() => {});
         },
+        onPrClosed: (issueId, prUrl, issueTitle, issueUrl) => {
+          // No issue labels available in this callback — fall back to primary channel
+          const target = project.channels[0];
+          notify(
+            {
+              type: "prClosed",
+              project: project.name,
+              issueId,
+              issueUrl,
+              issueTitle,
+              prUrl: prUrl ?? undefined,
+            },
+            {
+              workspaceDir,
+              config: notifyConfig,
+              groupId: target?.groupId,
+              channel: target?.channel ?? "telegram",
+            },
+          ).catch(() => {});
+        },
       });
 
       // Budget check: stop if we've hit the limit

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -297,6 +297,18 @@ export class TestProvider implements IssueProvider {
     // no-op in test provider
   }
 
+  async issueCommentHasReaction(_issueId: number, _commentId: number, _emoji: string): Promise<boolean> {
+    return false; // test provider: no existing reactions
+  }
+
+  async prCommentHasReaction(_issueId: number, _commentId: number, _emoji: string): Promise<boolean> {
+    return false; // test provider: no existing reactions
+  }
+
+  async prReviewHasReaction(_issueId: number, _reviewId: number, _emoji: string): Promise<boolean> {
+    return false; // test provider: no existing reactions
+  }
+
   async isCommitOnBaseBranch(_issueId: number, _baseBranch: string): Promise<boolean> {
     return false; // no-op in test provider
   }

--- a/lib/workflow.ts
+++ b/lib/workflow.ts
@@ -73,6 +73,7 @@ export const WorkflowEvent = {
   BLOCKED: "BLOCKED",
   APPROVE: "APPROVE",
   REJECT: "REJECT",
+  PR_CLOSED: "PR_CLOSED",
 } as const;
 
 export type TransitionTarget = string | {
@@ -150,6 +151,7 @@ export const DEFAULT_WORKFLOW: WorkflowConfig = {
         [WorkflowEvent.MERGE_FAILED]: "toImprove",
         [WorkflowEvent.CHANGES_REQUESTED]: "toImprove",
         [WorkflowEvent.MERGE_CONFLICT]: "toImprove",
+        [WorkflowEvent.PR_CLOSED]: "toImprove",
       },
     },
     reviewing: {
@@ -496,6 +498,7 @@ const FEEDBACK_EVENTS: Set<string> = new Set([
   WorkflowEvent.MERGE_FAILED,
   WorkflowEvent.REJECT,
   WorkflowEvent.FAIL,
+  WorkflowEvent.PR_CLOSED,
 ]);
 
 /**


### PR DESCRIPTION
Addresses issue #316

## Problem

When a PR is closed without merging, the issue was silently stalled in "To Review" indefinitely with no notification. After #315 (now merged), `PrState.CLOSED` with non-null URL means the PR was explicitly closed — not that no PR exists.

## Changes

### `lib/workflow.ts`
- Added `WorkflowEvent.PR_CLOSED = 'PR_CLOSED'`
- Added `PR_CLOSED → toImprove` transition to default `toReview` state
- Added `PR_CLOSED` to `FEEDBACK_EVENTS` (re-dispatched dev gets PR feedback context)

### `lib/services/review.ts`
- Added `onPrClosed` callback parameter to `reviewPass`
- Handler: `PrState.CLOSED + url non-null` → fire `PR_CLOSED` transition
- Preserves: `PrState.CLOSED + url null` → no-op (no PR exists, existing behavior)
- Audit-logged with `reason: 'pr_closed'` and the closed PR url

### `lib/notify.ts`
- Added `'prClosed'` `NotifyEvent` type
- Message: "🚫 PR closed without merging for #N: title"

### `lib/services/heartbeat.ts`
- Wired `onPrClosed` callback alongside existing `onFeedback`

### `lib/testing/test-provider.ts`
- Added stub implementations for `issueCommentHasReaction`, `prCommentHasReaction`, `prReviewHasReaction`

### `lib/services/pipeline.e2e.test.ts` — 3 new tests
1. PR closed + url non-null → transitions To Review → To Improve, fires `onPrClosed`, does NOT call mergePr
2. PR closed + url null → no transition (no PR exists — preserves existing behavior)
3. Workflow without `PR_CLOSED` configured → graceful no-op