### PR TITLE
feat: add accountId support to notification pipeline (#323)

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -219,29 +219,30 @@ async function sendMessage(
   channel: string,
   workspaceDir: string,
   runtime?: PluginRuntime,
+  accountId?: string,
 ): Promise<boolean> {
   try {
     // Use runtime API when available (avoids CLI subprocess timeouts)
     if (runtime) {
       if (channel === "telegram") {
         // Cast to any to bypass TypeScript type limitation; disableWebPagePreview is valid in Telegram API
-        await runtime.channel.telegram.sendMessageTelegram(target, message, { silent: true, disableWebPagePreview: true } as any);
+        await runtime.channel.telegram.sendMessageTelegram(target, message, { silent: true, disableWebPagePreview: true, accountId } as any);
         return true;
       }
       if (channel === "whatsapp") {
-        await runtime.channel.whatsapp.sendMessageWhatsApp(target, message, { verbose: false });
+        await runtime.channel.whatsapp.sendMessageWhatsApp(target, message, { verbose: false, accountId });
         return true;
       }
       if (channel === "discord") {
-        await runtime.channel.discord.sendMessageDiscord(target, message);
+        await runtime.channel.discord.sendMessageDiscord(target, message, { accountId });
         return true;
       }
       if (channel === "slack") {
-        await runtime.channel.slack.sendMessageSlack(target, message);
+        await runtime.channel.slack.sendMessageSlack(target, message, { accountId });
         return true;
       }
       if (channel === "signal") {
-        await runtime.channel.signal.sendMessageSignal(target, message);
+        await runtime.channel.signal.sendMessageSignal(target, message, { accountId });
         return true;
       }
     }
@@ -294,6 +295,8 @@ export async function notify(
     channel?: string;
     /** Plugin runtime for direct API access (avoids CLI subprocess timeouts) */
     runtime?: PluginRuntime;
+    /** Optional account ID for multi-account setups */
+    accountId?: string;
   },
 ): Promise<boolean> {
   if (opts.config?.[event.type] === false) return true;
@@ -317,7 +320,7 @@ export async function notify(
     message,
   });
 
-  return sendMessage(target, message, channel, opts.workspaceDir, opts.runtime);
+  return sendMessage(target, message, channel, opts.workspaceDir, opts.runtime, opts.accountId);
 }
 
 /**

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -95,6 +95,7 @@ export type Channel = {
   channel: "telegram" | "whatsapp" | "discord" | "slack";
   name: string; // e.g. "primary", "dev-chat"
   events: string[]; // e.g. ["*"] for all, ["workerComplete"] for filtered
+  accountId?: string; // Optional account ID for multi-account setups
 };
 
 /**


### PR DESCRIPTION
Addresses issue #323

## Problem

Discord notifications fail in multi-account setups because `accountId` cannot be passed through the notification pipeline. This task adds the necessary type definitions and updates `sendMessage()` to support `accountId`.

## Changes

### `lib/projects.ts`
- Added optional `accountId?: string` field to `Channel` type
- Enables per-channel account specification in projects.json

### `lib/notify.ts`
- Added optional `accountId?: string` to `notify()` opts parameter
- Added optional `accountId?: string` to `sendMessage()` parameter
- Passes `accountId` in all five channel send calls:
  - **Telegram:** `sendMessageTelegram` with `{ silent, disableWebPagePreview, accountId }`
  - **WhatsApp:** `sendMessageWhatsApp` with `{ verbose, accountId }`
  - **Discord:** `sendMessageDiscord` with `{ accountId }` ← fixes issue #320
  - **Slack:** `sendMessageSlack` with `{ accountId }`
  - **Signal:** `sendMessageSignal` with `{ accountId }`
- Wired `accountId` from `notify()` → `sendMessage()`

## Backwards Compatibility

✅ **SAFE.** All channel APIs treat `accountId` as **optional**:
- **Single-account setups:** `accountId` is `undefined` → uses default account (current behavior preserved)
- **Multi-account setups:** `accountId` is set → uses specified account (new capability)
- **No breaking changes:** Existing projects without `accountId` in Channel configs continue to work identically

## Testing

- ✅ TypeScript compilation succeeds with no type errors
- ✅ All existing tests pass (165 pass, 15 pre-existing failures unrelated to this change)
- ✅ Verified test results match main branch exactly

## Next Steps

Follow-up task will update all `notify()` call sites in the codebase to pass `accountId` from project channel configuration.