### PR TITLE
feat: add maxWorkers to role config (types, schema, loader) (#326)

### DIFF
--- a/defaults/devclaw/workflow.yaml
+++ b/defaults/devclaw/workflow.yaml
@@ -3,6 +3,7 @@
 
 roles:
   developer:
+    # maxWorkers: 3  # Maximum concurrent developer workers (default: 1)
     models:
       junior: anthropic/claude-haiku-4-5
       medior: anthropic/claude-sonnet-4-5

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -100,6 +100,7 @@ function resolve(config: DevClawConfig): ResolvedConfig {
         // Disabled role — include with enabled: false for visibility
         const reg = ROLE_REGISTRY[id];
         roles[id] = {
+          maxWorkers: 1,
           levels: reg ? [...reg.levels] : [],
           defaultLevel: reg?.defaultLevel ?? "",
           models: reg ? { ...reg.models } : {},
@@ -112,6 +113,7 @@ function resolve(config: DevClawConfig): ResolvedConfig {
 
       const reg = ROLE_REGISTRY[id];
       roles[id] = {
+        maxWorkers: override.maxWorkers ?? 1,
         levels: override.levels ?? (reg ? [...reg.levels] : []),
         defaultLevel: override.defaultLevel ?? reg?.defaultLevel ?? "",
         models: { ...(reg?.models ?? {}), ...(override.models ?? {}) },
@@ -126,6 +128,7 @@ function resolve(config: DevClawConfig): ResolvedConfig {
   for (const [id, reg] of Object.entries(ROLE_REGISTRY)) {
     if (!roles[id]) {
       roles[id] = {
+        maxWorkers: 1,
         levels: [...reg.levels],
         defaultLevel: reg.defaultLevel,
         models: { ...reg.models },

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -39,6 +39,7 @@ const WorkflowConfigSchema = z.object({
 const RoleOverrideSchema = z.union([
   z.literal(false),
   z.object({
+    maxWorkers: z.number().int().positive().optional(),
     levels: z.array(z.string()).optional(),
     defaultLevel: z.string().optional(),
     models: z.record(z.string(), z.string()).optional(),

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -11,6 +11,7 @@ import type { WorkflowConfig } from "../workflow.js";
  * Set to `false` to disable a role entirely for a project.
  */
 export type RoleOverride = {
+  maxWorkers?: number; // Maximum concurrent workers for this role (default: 1)
   levels?: string[];
   defaultLevel?: string;
   models?: Record<string, string>;
@@ -69,6 +70,7 @@ export type ResolvedConfig = {
  * Fully resolved role config — all fields present.
  */
 export type ResolvedRoleConfig = {
+  maxWorkers: number; // Maximum concurrent workers for this role (always resolved, default: 1)
   levels: string[];
   defaultLevel: string;
   models: Record<string, string>;

--- a/lib/roles/registry.test.ts
+++ b/lib/roles/registry.test.ts
@@ -144,7 +144,7 @@ describe("models", () => {
   });
 
   it("should resolve from resolved role config override", () => {
-    const resolvedRole = { models: { junior: "custom/model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
+    const resolvedRole = { maxWorkers: 1, models: { junior: "custom/model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
     assert.strictEqual(resolveModel("developer", "junior", resolvedRole), "custom/model");
   });
 
@@ -160,12 +160,12 @@ describe("models", () => {
     // "mid" alias maps to "medior" — should resolve to default medior model
     assert.strictEqual(resolveModel("developer", "mid"), "anthropic/claude-sonnet-4-5");
     // With explicit override in resolved config
-    const resolvedRole = { models: { medior: "custom/old-config-model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
+    const resolvedRole = { maxWorkers: 1, models: { medior: "custom/old-config-model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
     assert.strictEqual(resolveModel("developer", "mid", resolvedRole), "custom/old-config-model");
   });
 
   it("should resolve with resolved role overriding defaults selectively", () => {
-    const resolvedRole = { models: { junior: "custom/model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
+    const resolvedRole = { maxWorkers: 1, models: { junior: "custom/model" }, levels: ["junior", "medior", "senior"], defaultLevel: "medior", emoji: {}, completionResults: [] as string[], enabled: true };
     assert.strictEqual(resolveModel("developer", "junior", resolvedRole), "custom/model");
     // Levels not overridden fall through to registry defaults
     assert.strictEqual(resolveModel("developer", "medior", resolvedRole), "anthropic/claude-sonnet-4-5");

--- a/lib/tools/research-task.test.ts
+++ b/lib/tools/research-task.test.ts
@@ -33,7 +33,7 @@ describe("architect tiers", () => {
   });
 
   it("should resolve architect model from resolved role config", () => {
-    const resolvedRole = { models: { senior: "custom/model" }, levels: ["junior", "senior"], defaultLevel: "junior", emoji: {}, completionResults: [] as string[], enabled: true };
+    const resolvedRole = { maxWorkers: 1, models: { senior: "custom/model" }, levels: ["junior", "senior"], defaultLevel: "junior", emoji: {}, completionResults: [] as string[], enabled: true };
     assert.strictEqual(resolveModel("architect", "senior", resolvedRole), "custom/model");
   });
 

--- a/lib/tools/workflow-guide.ts
+++ b/lib/tools/workflow-guide.ts
@@ -210,6 +210,7 @@ function buildRolesSection(): string {
 
 | Field              | Constrained?  | Notes |
 |-------------------|---------------|-------|
+| \`maxWorkers\`      | Must be positive integer | Maximum concurrent workers for this role. Default: 1. |
 | \`levels\`          | FREE — array of strings | Define your own level names. Default model routing uses these as keys. |
 | \`defaultLevel\`    | Must be one of \`levels\` | Used when no level specified on issue. |
 | \`models\`          | FREE — map of level→model ID | Model IDs are free-form strings. Format: \`provider/model-name\`. |
@@ -448,6 +449,13 @@ roles:
       junior: google/gemini-2.0-flash
       medior: google/gemini-2.5-pro
       senior: anthropic/claude-opus-4-6
+\`\`\`
+
+### Allow concurrent developers on a project
+\`\`\`yaml
+roles:
+  developer:
+    maxWorkers: 3  # Allow up to 3 developers working in parallel
 \`\`\`
 
 ### Override timeouts for a slow repo


### PR DESCRIPTION
Addresses issue #326

## Overview

Adds `maxWorkers` configuration to role config for controlling concurrent worker limits per role. This is a type-system and configuration change only - consumer code will read this value in future PRs to implement actual concurrency limits.

**Default**: 1 (preserves current single-worker behavior)

## Changes Made

### Type Definitions (`lib/config/types.ts`)

**RoleOverride** (optional):
```typescript
export type RoleOverride = {
  maxWorkers?: number; // Maximum concurrent workers for this role (default: 1)
  levels?: string[];
  defaultLevel?: string;
  // ... other fields
};
```

**ResolvedRoleConfig** (required):
```typescript
export type ResolvedRoleConfig = {
  maxWorkers: number; // Always resolved, default: 1
  levels: string[];
  defaultLevel: string;
  // ... other fields
};
```

### Schema Validation (`lib/config/schema.ts`)

Added to RoleOverrideSchema:
```typescript
maxWorkers: z.number().int().positive().optional(),
```

Enforces:
- Must be a positive integer
- Optional (defaults to 1 if not specified)

### Config Loader (`lib/config/loader.ts`)

Added default resolution in `resolve()` function:
```typescript
roles[id] = {
  maxWorkers: override.maxWorkers ?? 1,  // NEW
  levels: override.levels ?? (reg ? [...reg.levels] : []),
  // ... other fields
};
```

Applied to all three code paths:
1. Disabled roles (`override === false`)
2. Roles with overrides
3. Built-in roles without config (fallback)

### Default Config (`defaults/devclaw/workflow.yaml`)

Added commented example:
```yaml
roles:
  developer:
    # maxWorkers: 3  # Maximum concurrent developer workers (default: 1)
    models:
      junior: anthropic/claude-haiku-4-5
      # ...
```

### Documentation (`lib/tools/workflow-guide.ts`)

**In role config fields table**:
| Field | Constrained? | Notes |
|-------|--------------|-------|
| `maxWorkers` | Must be positive integer | Maximum concurrent workers for this role. Default: 1. |

**In project-level overrides section**:
```yaml
### Allow concurrent developers on a project
roles:
  developer:
    maxWorkers: 3  # Allow up to 3 developers working in parallel
```

### Test Updates

**lib/roles/registry.test.ts**:
- Added `maxWorkers: 1` to all ResolvedRoleConfig test objects (4 instances)

**lib/tools/research-task.test.ts**:
- Added `maxWorkers: 1` to ResolvedRoleConfig test object (1 instance)

## Backwards Compatibility

✅ **COMPLETELY SAFE**:
- **Default value**: 1 (exact current behavior - single worker per role)
- **Optional field**: If not specified in config, defaults to 1
- **No functional change**: Consumer code doesn't read this value yet
- **All existing configs work**: No migration needed

## Configuration Examples

### Workspace-level (applies to all projects)
```yaml
# devclaw/workflow.yaml
roles:
  developer:
    maxWorkers: 3
  tester:
    maxWorkers: 2
```

### Project-level override
```yaml
# devclaw/projects/critical-app/workflow.yaml
roles:
  developer:
    maxWorkers: 5  # More workers for critical project
```

### Mixed configuration
```yaml
roles:
  developer:
    maxWorkers: 3
    models:
      senior: anthropic/claude-opus-4-6
  tester: false  # Disable tester role
```

## Validation

- ✅ TypeScript compiles without errors
- ✅ Schema validation enforces positive integer
- ✅ All tests pass (1 pre-existing failure unrelated to this change)
- ✅ Default config includes commented example

## Next Steps

This PR is foundational for concurrent worker support. Future PRs will:
1. Read `maxWorkers` from resolved role config
2. Implement worker slot tracking in heartbeat
3. Respect limits during queue dispatch
4. Update health checks to account for multiple workers

## Related

- From research #325: Concurrent worker design
- Foundation for future worker concurrency implementation