### PR TITLE
docs: update docs, changelog, and release artifacts for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to DevClaw will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.0] - 2026-02-19
+## [1.4.0] - 2026-02-22
 
 ### Added
 
+- **`upgrade` tool** — Automatic plugin and workspace upgrades. Checks npm for newer versions, installs via `openclaw plugins install`, then upgrades workspace docs, prompts, and workflow states to match the running version (with `.bak` backups). Preserves roles, timeouts, and project-level prompt overrides.
+- **`sync_labels` tool** — Synchronize GitHub/GitLab labels with the current workflow config. Creates any missing state labels, role:level labels, and step routing labels from the resolved three-layer config. Use after editing `workflow.yaml` to push label changes to your issue tracker.
+- **Slot-based worker pools** — Workers now support multiple concurrent slots per role level via `maxWorkers` / `maxWorkersPerLevel` in `workflow.yaml`. The dispatch engine, health checks, status dashboard, and project registration all support multi-slot workers.
+- **PR closure handling** — Closing a PR without merging now transitions the issue to `Rejected` state with proper issue closure. New `PR_CLOSED` event in workflow transitions.
+- **accountId support in notifications** — All `notify()` call sites now pass `accountId` and `runtime` for channel-aware notification routing.
+- **PR_CLOSED event in review pass** — Heartbeat detects closed (unmerged) PRs in `To Review` and auto-transitions to `To Improve` for developer action.
 - **Externalized defaults & `reset_defaults` tool** — All built-in templates (AGENTS.md, HEARTBEAT.md, IDENTITY.md, TOOLS.md, workflow states, role prompts) moved to a `defaults/` directory. New `reset_defaults` tool restores workspace files to factory settings with `.bak` backups, with warnings about project-level prompt overrides.
 - **Eyes marker (👀) on managed issues/PRs** — DevClaw adds an eyes marker to issue and PR bodies it manages, distinguishing them from legacy or manually-created items.
 - **Comment consumption tracking with reactions** — Processed comments receive emoji reactions so workers don't re-read already-handled feedback on subsequent dispatches.
@@ -17,10 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`projects.json` is pure runtime state** — All configuration moved to `workflow.yaml`; `projects.json` only tracks runtime worker state. Simplifies the config story.
+- **Bootstrap hook replaces AGENTS.md injection** — Worker sessions now receive role-specific instructions via the `agent:bootstrap` hook instead of AGENTS.md file replacement.
 - **Safe two-phase label transitions** — Label changes on GitHub/GitLab use a two-phase commit (add new → remove old) to prevent half-states on API failures.
 - **PR review detection improvements** — More reliable detection of review approvals, change requests, and conversation comments across GitHub and GitLab providers.
 - **TOOLS.md template improvements** — Cleaner generated tool documentation for new workspaces.
-- **16 tools** (was 14) — added `reset_defaults`, `tasks_status`, `task_list` (replaced `status` and `work_heartbeat`)
+- **18 tools** (was 14) — added `reset_defaults`, `tasks_status`, `task_list`, `upgrade`, `sync_labels` (replaced `status` and `work_heartbeat`)
+
+### Fixed
+
+- **Architect prompt** — Enforces single comprehensive task with checklist format instead of multiple small tasks.
+- **GitHub PR comment emoji marking** — Fixed consumption tracking for PR review comments.
+- **PR state property** — `findPrsViaTimeline` now returns `state` property; `getPrStatus` distinguishes closed-PR from no-PR.
+- **Workflow.yaml comments** — Corrected comments and formatting for clarity.
+
+### Removed
+
+- **Orphaned session scan** — Removed from health and heartbeat services (was causing false positives).
 
 ## [1.3.6] - 2026-02-18
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ GitHub/GitLab issues are the single source of truth — not an internal database
 
 - **[External task state](#your-issues-stay-in-your-tracker)** — labels, transitions, and status queries go through your issue tracker
 - **[Atomic operations](#what-atomic-means-here)** — label transition + state update + session dispatch + audit log in one call
-- **[Tool-based guardrails](#the-toolbox)** — 16 tools enforce the process; the agent provides intent, the plugin handles mechanics
+- **[Tool-based guardrails](#the-toolbox)** — 18 tools enforce the process; the agent provides intent, the plugin handles mechanics
 
 ### ~60-80% token savings
 
@@ -437,6 +437,14 @@ openclaw plugins install @laurentenhoor/devclaw
 
 ### Upgrade
 
+The easiest way to upgrade is through your agent:
+```
+You: "Upgrade DevClaw"
+```
+
+The `upgrade` tool checks npm for newer versions, installs the update, and upgrades workspace files (docs, prompts, workflow states) with `.bak` backups — preserving your customizations.
+
+Or manually:
 ```bash
 openclaw plugins install @laurentenhoor/devclaw
 ```
@@ -485,7 +493,7 @@ You can also use the [CLI wizard or non-interactive setup](docs/ONBOARDING.md#st
 
 ## The toolbox
 
-DevClaw gives the orchestrator 16 tools. These aren't just convenience wrappers — they're **guardrails**. Each tool encodes a complex multi-step operation into a single atomic call. The agent provides intent, the plugin handles mechanics. The agent physically cannot skip a label transition, forget to update state, or dispatch to the wrong session — those decisions are made by deterministic code, not LLM reasoning.
+DevClaw gives the orchestrator 18 tools. These aren't just convenience wrappers — they're **guardrails**. Each tool encodes a complex multi-step operation into a single atomic call. The agent provides intent, the plugin handles mechanics. The agent physically cannot skip a label transition, forget to update state, or dispatch to the wrong session — those decisions are made by deterministic code, not LLM reasoning.
 
 | Tool | What it does |
 |---|---|
@@ -505,6 +513,8 @@ DevClaw gives the orchestrator 16 tools. These aren't just convenience wrappers 
 | `autoconfigure_models` | LLM-powered model selection based on available models |
 | `workflow_guide` | Configuration reference for workflow.yaml (call before editing) |
 | `reset_defaults` | Restore workspace files to built-in defaults (creates `.bak` backups) |
+| `upgrade` | Upgrade plugin and workspace files — checks npm, installs, upgrades docs/prompts/states |
+| `sync_labels` | Sync GitHub/GitLab labels with workflow config after editing `workflow.yaml` |
 
 Full parameters and usage in the [Tools Reference](docs/TOOLS.md).
 
@@ -516,7 +526,7 @@ Full parameters and usage in the [Tools Reference](docs/TOOLS.md).
 |---|---|
 | **[Architecture](docs/ARCHITECTURE.md)** | System design, session model, data flow, end-to-end diagrams |
 | **[Workflow](docs/WORKFLOW.md)** | State machine, review policies, optional test phase |
-| **[Tools Reference](docs/TOOLS.md)** | Complete reference for all 16 tools |
+| **[Tools Reference](docs/TOOLS.md)** | Complete reference for all 18 tools |
 | **[Configuration](docs/CONFIGURATION.md)** | `openclaw.json`, `projects.json`, roles, timeouts |
 | **[Onboarding Guide](docs/ONBOARDING.md)** | Full step-by-step setup |
 | **[Testing](docs/TESTING.md)** | Test suite, fixtures, CI/CD |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,18 @@ DEVELOPER completes work (`result: "done"`), which transitions the issue to `To 
 
 The architect role enables design investigations. `research_task` creates an issue and dispatches an architect worker through dedicated `To Research` → `Researching` states. The architect posts findings as comments, creates implementation tasks in Planning, then completes with `done` or `blocked` (→ Refining).
 
+### Slot-Based Worker Pools
+
+Workers now support multiple concurrent slots per role level via `maxWorkers` / `maxWorkersPerLevel` in `workflow.yaml`. The data model (`WorkerState`), dispatch engine (`tick.ts`, `work-start.ts`), health checks, status dashboard, and project registration all support multi-slot workers. Session keys use slot-indexed naming for isolation.
+
+### Upgrade and Label Sync Tools
+
+Two new maintenance tools: `upgrade` checks npm for newer versions, installs updates, and upgrades workspace files with `.bak` backups. `sync_labels` synchronizes GitHub/GitLab labels with the resolved workflow config after editing `workflow.yaml`.
+
+### PR Closure and Rejection Handling
+
+Closing a PR without merging now transitions the associated issue to `Rejected` state with proper issue closure. The workflow state machine supports a new `PR_CLOSED` event in transitions.
+
 ### Workspace Layout Migration
 
 Data directory moved from `<workspace>/projects/` to `<workspace>/devclaw/`. Automatic migration on first load — see `lib/setup/migrate-layout.ts`.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # DevClaw — Tools Reference
 
-Complete reference for all 16 tools registered by DevClaw. See [`index.ts`](../index.ts) for registration.
+Complete reference for all 18 tools registered by DevClaw. See [`index.ts`](../index.ts) for registration.
 
 ## Worker Lifecycle
 
@@ -467,3 +467,50 @@ When the heartbeat fills free worker slots, issues are prioritized:
 3. **To Do** — Fresh tasks are picked up last
 
 This ensures the pipeline clears its backlog before starting new work.
+
+---
+
+## Maintenance
+
+### `upgrade`
+
+Upgrade DevClaw plugin and workspace files. Checks npm for a newer published version, installs it via `openclaw plugins install`, then upgrades workspace docs, default prompts, and workflow states to match the running version (with `.bak` backups). Preserves roles, timeouts, and project-level prompt overrides.
+
+**Source:** [`lib/tools/upgrade.ts`](../lib/tools/upgrade.ts)
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `skipNpmCheck` | boolean | No | Skip npm version check and only upgrade workspace files. Default: `false`. |
+
+**What it does:**
+
+1. Checks npm registry for a newer version of `@laurentenhoor/devclaw`
+2. Installs the update via `openclaw plugins install`
+3. Upgrades workspace docs (AGENTS.md, HEARTBEAT.md, etc.) to match the running version
+4. Creates `.bak` backups of any modified files
+5. Preserves user customizations in roles, timeouts, and project-level prompts
+
+---
+
+### `sync_labels`
+
+Sync GitHub/GitLab labels with the current workflow config. Creates any missing state labels, role:level labels, and step routing labels from the resolved (three-layer merged) config.
+
+**Source:** [`lib/tools/sync-labels.ts`](../lib/tools/sync-labels.ts)
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `projectSlug` | string | No | Project slug to sync. Omit to sync all registered projects. |
+
+**What it does:**
+
+1. Loads the resolved workflow config (built-in → workspace → project)
+2. Derives all required labels: state labels, role:level labels, step routing labels
+3. Creates any missing labels on the GitHub/GitLab repo via the provider
+4. Reports created vs. already-existing labels
+
+**When to use:** After editing `workflow.yaml` to add custom states, change label names, or enable the test phase.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -401,5 +401,5 @@ Call the `workflow_guide` tool for interactive documentation. It returns compreh
 ## Related
 
 - [Configuration](CONFIGURATION.md) — Config file format, roles, timeouts, `openclaw.json`
-- [Tools Reference](TOOLS.md) — All 16 tools including `work_start`, `work_finish`, `task_list`, `workflow_guide`
+- [Tools Reference](TOOLS.md) — All 18 tools including `work_start`, `work_finish`, `task_list`, `workflow_guide`
 - [Architecture](ARCHITECTURE.md) — System design, session model, heartbeat internals


### PR DESCRIPTION
Addresses issue #392

## Changes

- **CHANGELOG.md** — Complete v1.4.0 entry with all features since v1.3.6: upgrade tool, sync_labels tool, slot-based worker pools, PR closure/rejection handling, accountId notifications, bootstrap hook changes, architect prompt fix, and more
- **README.md** — Updated tool count (16→18), added upgrade/sync_labels to toolbox table, improved upgrade section with agent-first instructions
- **docs/TOOLS.md** — Added full reference entries for `upgrade` and `sync_labels` tools, updated tool count
- **docs/WORKFLOW.md** — Updated tool count reference
- **docs/ROADMAP.md** — Added slot-based worker pools, upgrade/sync_labels tools, and PR closure handling to completed section

## Notes

Version is already 1.4.0 in package.json. GitHub Release will be created after merge.