### PR TITLE
Mark newly created PRs and MRs as seen with eye emoji reaction

### DIFF
--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -127,6 +127,14 @@ export async function executeCompletion(opts: {
           auditLog(workspaceDir, "pipeline_warning", { step: "mergePr", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
         }
         break;
+      case Action.MARK_PR_AS_SEEN:
+        try {
+          // Mark the newly created PR/MR with an eye emoji reaction
+          await provider.reactToPr(issueId, "eyes");
+        } catch (err) {
+          auditLog(workspaceDir, "pipeline_warning", { step: "markPrAsSeen", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
+        }
+        break;
     }
   }
 

--- a/lib/workflow.ts
+++ b/lib/workflow.ts
@@ -56,6 +56,7 @@ export const Action = {
   MERGE_PR: "mergePr",
   CLOSE_ISSUE: "closeIssue",
   REOPEN_ISSUE: "reopenIssue",
+  MARK_PR_AS_SEEN: "markPrAsSeen",
 } as const;
 
 /** Built-in review check types for review states. */
@@ -148,7 +149,7 @@ export const DEFAULT_WORKFLOW: WorkflowConfig = {
       label: "Doing",
       color: "#f0ad4e",
       on: {
-        [WorkflowEvent.COMPLETE]: { target: "toReview", actions: [Action.DETECT_PR] },
+        [WorkflowEvent.COMPLETE]: { target: "toReview", actions: [Action.DETECT_PR, Action.MARK_PR_AS_SEEN] },
         [WorkflowEvent.BLOCKED]: "refining",
       },
     },


### PR DESCRIPTION
Addresses issue #409

## Changes
- Added new action  to the workflow Action enum
- Implemented handler in pipeline service to react to PRs/MRs with eye emoji
- Updated default workflow to automatically mark PRs as seen when developer completes work

## How it works
When a developer marks their work as done (`work_finish(done)`), the newly created PR/MR is automatically marked with an eye emoji (👀) reaction. This works for both GitHub PRs and GitLab MRs through the existing `reactToPr` provider methods.

The action is added to the developer workflow transition from 'Doing' to 'To Review' state, ensuring that every newly created PR gets marked immediately.

## Testing
The implementation reuses existing provider methods (`reactToPr` on both GitHub and GitLab) which are already in place for other functionality.