### PR TITLE
feat: automatically mark PRs as seen when detected

### DIFF
--- a/lib/tools/work-finish.ts
+++ b/lib/tools/work-finish.ts
@@ -70,6 +70,18 @@ async function validatePrExistsForDeveloper(
     // url is set — an open or merged PR exists and is linked to this issue.
     // getPrStatus locates PRs via the issue tracker's linked-PR API, so any
     // non-null url already implies the PR references the issue.
+
+    // Mark PR as "seen" (with eyes emoji) if not already marked.
+    // This helps distinguish system-created PRs from human responses.
+    // Best-effort — don't block completion if this fails.
+    try {
+      const hasEyes = await provider.prHasReaction(issueId, "eyes");
+      if (!hasEyes) {
+        await provider.reactToPr(issueId, "eyes");
+      }
+    } catch {
+      // Ignore errors — marking is cosmetic
+    }
   } catch (err) {
     // Re-throw our own validation errors; swallow provider/network errors.
     // Swallowing keeps work_finish unblocked when the API is unreachable.


### PR DESCRIPTION
Addresses issue #409

## Problem
The initial implementation (PR #411) incorrectly added the eye emoji marking as a workflow action. The actual requirement was simpler: mark PRs as "seen" immediately when they're first detected, similar to how issues are marked when created.

## Solution
Modified `validatePrExistsForDeveloper()` in `lib/tools/work-finish.ts` to:
1. Check if the PR already has an eyes emoji reaction using `prHasReaction()`
2. If not, add the eyes emoji using `reactToPr()`
3. All operations are best-effort (don't block completion on failure)

## Behavior
When a developer calls `work_finish(done)`:
- The system validates that a PR exists
- If the PR is unmarked, it gets the 👀 emoji
- This happens once per PR (checked via `prHasReaction`)
- Human responses on the PR remain unmarked, making them easy to identify

## Benefits
- Consistent with issue marking behavior
- Works for both GitHub and GitLab
- Non-blocking (cosmetic feature)
- Helps identify which PR comments need human attention