### PR TITLE
Auto-assign owner label to task modifications

### DIFF
--- a/lib/tool-helpers.ts
+++ b/lib/tool-helpers.ts
@@ -8,6 +8,9 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { ToolContext } from "./types.js";
 import { readProjects, getProject, type Project, type ProjectsData } from "./projects.js";
 import { createProvider, type ProviderWithType } from "./providers/index.js";
+import { loadConfig } from "./config/index.js";
+import { loadInstanceName } from "./instance.js";
+import { getOwnerLabel, OWNER_LABEL_COLOR } from "./workflow.js";
 
 /**
  * Require workspaceDir from context or throw a clear error.
@@ -48,4 +51,36 @@ export async function resolveProvider(project: Project): Promise<ProviderWithTyp
  */
 export function getPluginConfig(api: OpenClawPluginApi): Record<string, unknown> | undefined {
   return api.pluginConfig as Record<string, unknown> | undefined;
+}
+
+/**
+ * Auto-assign owner label to an issue based on the current instance.
+ *
+ * This ensures that when a task tool creates or modifies an issue,
+ * it automatically claims ownership for the executing instance.
+ * Best-effort: failures are logged but don't block the operation.
+ */
+export async function autoAssignOwnerLabel(
+  workspaceDir: string,
+  provider: ProviderWithType["provider"],
+  issueId: number,
+  project: Project,
+): Promise<void> {
+  try {
+    const resolvedConfig = await loadConfig(workspaceDir, project.name);
+    const instanceName = await loadInstanceName(
+      workspaceDir,
+      resolvedConfig.instanceName,
+    );
+    const ownerLabel = getOwnerLabel(instanceName);
+
+    // Ensure the owner label exists in the issue tracker
+    await provider.ensureLabel(ownerLabel, OWNER_LABEL_COLOR);
+
+    // Add the owner label to the issue
+    await provider.addLabel(issueId, ownerLabel);
+  } catch (error) {
+    // Log but don't block: auto-assigning owner label is best-effort
+    console.warn(`Failed to auto-assign owner label to issue #${issueId}:`, error);
+  }
 }

--- a/lib/tools/research-task.ts
+++ b/lib/tools/research-task.ts
@@ -19,7 +19,7 @@ import type { StateLabel } from "../providers/provider.js";
 import { getRoleWorker, countActiveSlots } from "../projects.js";
 import { dispatchTask } from "../dispatch.js";
 import { log as auditLog } from "../audit.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider, getPluginConfig } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, getPluginConfig, autoAssignOwnerLabel } from "../tool-helpers.js";
 import { loadConfig } from "../config/index.js";
 import { getNotifyLabel, NOTIFY_LABEL_COLOR, NOTIFY_LABEL_PREFIX, getActiveLabel } from "../workflow.js";
 import { selectLevel } from "../model-selector.js";
@@ -150,6 +150,9 @@ Example:
             .catch(() => {});
         }
       }
+
+      // Auto-assign owner label to this instance (best-effort).
+      autoAssignOwnerLabel(workspaceDir, provider, issue.iid, project).catch(() => {});
 
       // Check worker availability across all levels
       const roleWorker = getRoleWorker(project, role);

--- a/lib/tools/task-attach.ts
+++ b/lib/tools/task-attach.ts
@@ -10,7 +10,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../types.js";
 import { log as auditLog } from "../audit.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, autoAssignOwnerLabel } from "../tool-helpers.js";
 import {
   listAttachments,
   saveAttachment,
@@ -133,6 +133,9 @@ Use cases:
         // Post comment on issue
         const comment = formatAttachmentComment([meta]);
         await provider.addComment(issueId, comment);
+
+        // Auto-assign owner label to this instance (best-effort).
+        autoAssignOwnerLabel(workspaceDir, provider, issueId, project).catch(() => {});
 
         await auditLog(workspaceDir, "task_attach", {
           project: project.name,

--- a/lib/tools/task-comment.ts
+++ b/lib/tools/task-comment.ts
@@ -10,7 +10,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../types.js";
 import { log as auditLog } from "../audit.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, autoAssignOwnerLabel } from "../tool-helpers.js";
 import { getAllRoleIds, getFallbackEmoji } from "../roles/index.js";
 
 /** Valid author roles for attribution — all registry roles + orchestrator */
@@ -81,6 +81,9 @@ Examples:
 
       // Mark as system-managed (best-effort).
       provider.reactToIssueComment(issueId, commentId, "eyes").catch(() => {});
+
+      // Auto-assign owner label to this instance (best-effort).
+      autoAssignOwnerLabel(workspaceDir, provider, issueId, project).catch(() => {});
 
       await auditLog(workspaceDir, "task_comment", {
         project: project.name, issueId,

--- a/lib/tools/task-create.ts
+++ b/lib/tools/task-create.ts
@@ -15,7 +15,7 @@ import type { ToolContext } from "../types.js";
 import { log as auditLog } from "../audit.js";
 import type { StateLabel } from "../providers/provider.js";
 import { DEFAULT_WORKFLOW, getStateLabels, getNotifyLabel, NOTIFY_LABEL_COLOR } from "../workflow.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, autoAssignOwnerLabel } from "../tool-helpers.js";
 
 /** Derive the initial state label from the workflow config. */
 const INITIAL_LABEL = DEFAULT_WORKFLOW.states[DEFAULT_WORKFLOW.initial].label;
@@ -89,6 +89,9 @@ Examples:
           .then(() => provider.addLabel(issue.iid, notifyLabel))
           .catch(() => {}); // best-effort
       }
+
+      // Auto-assign owner label to this instance (best-effort).
+      autoAssignOwnerLabel(workspaceDir, provider, issue.iid, project).catch(() => {});
 
       await auditLog(workspaceDir, "task_create", {
         project: project.name, issueId: issue.iid,

--- a/lib/tools/task-edit-body.ts
+++ b/lib/tools/task-edit-body.ts
@@ -14,7 +14,7 @@ import type { ToolContext } from "../types.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { getInitialStateLabel, getCurrentStateLabel } from "../workflow.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, autoAssignOwnerLabel } from "../tool-helpers.js";
 
 export function createTaskEditBodyTool(_api: OpenClawPluginApi) {
   return (ctx: ToolContext) => ({
@@ -128,6 +128,9 @@ Examples:
         ...(newTitle !== undefined ? { title: newTitle } : {}),
         ...(newBody !== undefined ? { body: newBody } : {}),
       });
+
+      // Auto-assign owner label to this instance (best-effort).
+      autoAssignOwnerLabel(workspaceDir, provider, issueId, project).catch(() => {});
 
       // Post auto-comment for traceability (best-effort — must not abort on failure)
       if (addComment) {

--- a/lib/tools/task-update.ts
+++ b/lib/tools/task-update.ts
@@ -13,7 +13,7 @@ import { log as auditLog } from "../audit.js";
 import type { StateLabel } from "../providers/provider.js";
 import { DEFAULT_WORKFLOW, getStateLabels, findStateByLabel, getCurrentStateLabel, getRoleLabelColor } from "../workflow.js";
 import { loadConfig } from "../config/index.js";
-import { requireWorkspaceDir, resolveProject, resolveProvider } from "../tool-helpers.js";
+import { requireWorkspaceDir, resolveProject, resolveProvider, autoAssignOwnerLabel } from "../tool-helpers.js";
 
 export function createTaskUpdateTool(api: OpenClawPluginApi) {
   return (ctx: ToolContext) => ({
@@ -123,6 +123,9 @@ Examples:
         await provider.addLabel(issueId, newRoleLabel);
         levelChanged = fromLevel !== newLevel;
       }
+
+      // Auto-assign owner label to this instance (best-effort).
+      autoAssignOwnerLabel(workspaceDir, provider, issueId, project).catch(() => {});
 
       // Audit
       await auditLog(workspaceDir, "task_update", {


### PR DESCRIPTION
Addresses issue #421

## Summary

Implements automatic owner label assignment for all task modification tools to support multi-instance setups where multiple orchestrators manage the same project.

## Changes

- **New Helper Function**: Added  in  to centralize owner label assignment logic
- **Integrated Into All Task Tools**: 
  - : Assigns owner label after issue creation
  - : Assigns owner label after state/level updates
  - : Assigns owner label after adding comments
  - : Assigns owner label after editing title/description
  - : Assigns owner label when attaching files
  - : Assigns owner label when creating research issues

## Implementation Details

- Uses existing  to get the current instance identifier
- Leverages the  label format (already defined in workflow.ts)
- Best-effort approach: errors are logged but don't block operations
- Prevents duplicate labels by using provider's existing  which is idempotent

## Benefits

- **Conflict Prevention**: Multiple instances can safely create/modify issues without conflicts
- **Queue Management**: Each instance can be responsible only for issues it created
- **Audit Trail**: Owner labels provide clear visibility into which instance owns each task
- **Seamless Integration**: Works with existing multi-instance coordination mechanisms