### PR TITLE
docs: update README workflow diagram to reflect all states and transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,23 +161,48 @@ Planning → To Research → Researching → Planning (architect findings)
 ```mermaid
 stateDiagram-v2
     [*] --> Planning
+
+    %% Planning routes
     Planning --> ToDo: Ready for development
     Planning --> ToResearch: Needs investigation
 
+    %% Research pipeline
     ToResearch --> Researching: Architect picks up
-    Researching --> Planning: Architect done (findings posted)
+    Researching --> Done: Architect done (creates tasks)
     Researching --> Refining: Architect blocked
 
+    %% Main development pipeline
     ToDo --> Doing: DEV picks up
     Doing --> ToReview: DEV done (opens PR)
     Doing --> Refining: DEV blocked
-    Refining --> ToDo: Human decides
 
-    ToReview --> Done: PR approved (auto-merge + close)
-    ToReview --> ToImprove: Changes requested / merge conflict
-    ToImprove --> Doing: Scheduler picks up DEV fix
+    %% Review flow (human or agent)
+    ToReview --> Reviewing: Reviewer picks up
+    ToReview --> ToTest: PR approved (auto-merge)
+    ToReview --> ToImprove: Changes requested
+    ToReview --> ToImprove: Merge conflict
+    ToReview --> Rejected: PR closed
 
+    Reviewing --> ToTest: Reviewer approves (merge)
+    Reviewing --> ToImprove: Reviewer rejects
+    Reviewing --> Refining: Reviewer blocked
+
+    %% Test phase (optional - skipped by default)
+    ToTest --> Testing: Tester picks up
+    ToTest --> Done: Skip test (default)
+    Testing --> Done: Tests pass
+    Testing --> ToImprove: Tests fail
+    Testing --> Refining: Tester blocked
+
+    %% Improvement loop
+    ToImprove --> Doing: DEV picks up fix
+
+    %% Human decision point
+    Refining --> ToDo: Human approves
+
+    %% Terminal states
     Done --> [*]
+    Rejected --> [*]
 ```
 
 By default, PRs go through **human review** on GitHub/GitLab. The heartbeat polls for approvals and auto-merges. You can switch to agent review or enable an [optional test phase](docs/WORKFLOW.md#test-phase-optional) in `workflow.yaml`.


### PR DESCRIPTION
Addresses issue #419

## Summary
Updated the mermaid workflow diagram in the README to accurately reflect the complete current workflow with all 13 states and their transitions.

## Changes

### States Added
- **Reviewing**: Agent review state (was missing)
- **To Test** and **Testing**: Optional test phase states
- **Rejected**: Terminal state for closed PRs without merge

### Transitions Clarified
- **Review flow**: Shows both automatic (To Review → To Test) and agent review (To Review → Reviewing → To Test) paths
- **Test phase**: Shows optional testing with skip transition (default behavior)
- **Improvement loop**: Clearly shows To Improve → Doing cycle for PR feedback and test failures
- **Blocked states**: Shows all paths to Refining (human decision point)

### Visual Improvements
- Organized states by pipeline stage to minimize crossing lines
- Added descriptive transition labels (e.g., "PR approved (auto-merge)")
- Grouped related states together (research, review, test)
- Used comments to section the diagram logically

## Workflow Coverage
The diagram now shows:
- ✅ Main development pipeline (Planning → ToDo → Doing → ToReview → ToTest → Done)
- ✅ Research pipeline (ToResearch → Researching)
- ✅ Review policies (human and agent)
- ✅ Test phase (optional, skipped by default)
- ✅ Improvement loops (ToImprove, Refining)
- ✅ All terminal states (Done, Rejected)

The diagram is clean, readable, and accurately represents the workflow defined in `lib/workflow.ts`.