### PR TITLE
fix: pass model to agent RPC call — subagents now respect workflow.yaml (#436)

### DIFF
--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -256,6 +256,7 @@ export async function dispatchTask(
     orchestratorSessionKey: opts.sessionKey, workspaceDir,
     dispatchTimeoutMs: timeouts.dispatchMs,
     extraSystemPrompt: roleInstructions.trim() || undefined,
+    model,
     runCommand: rc,
   });
 

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -84,7 +84,7 @@ export function ensureSessionFireAndForget(sessionKey: string, model: string, wo
 
 export function sendToAgent(
   sessionKey: string, taskMessage: string,
-  opts: { agentId?: string; projectName: string; issueId: number; role: string; level?: string; slotIndex?: number; orchestratorSessionKey?: string; workspaceDir: string; dispatchTimeoutMs?: number; extraSystemPrompt?: string; runCommand: RunCommand },
+  opts: { agentId?: string; projectName: string; issueId: number; role: string; level?: string; slotIndex?: number; orchestratorSessionKey?: string; workspaceDir: string; dispatchTimeoutMs?: number; extraSystemPrompt?: string; model?: string; runCommand: RunCommand },
 ): void {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
@@ -96,6 +96,7 @@ export function sendToAgent(
     lane: "subagent",
     ...(opts.orchestratorSessionKey ? { spawnedBy: opts.orchestratorSessionKey } : {}),
     ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
+    ...(opts.model ? { model: opts.model } : {}),
   });
   // Fire-and-forget: long-running agent turn, don't await
   rc(

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -36,6 +36,8 @@ export type CapturedCommand = {
   taskMessage?: string;
   /** Extracted from gateway `agent` call params, if applicable. */
   extraSystemPrompt?: string;
+  /** Extracted from gateway `agent` call params, if applicable. */
+  agentModel?: string;
   /** Extracted from gateway `sessions.patch` params, if applicable. */
   sessionPatch?: { key: string; model: string; label?: string };
 };
@@ -49,6 +51,8 @@ export type CommandInterceptor = {
   taskMessages(): string[];
   /** Get all extraSystemPrompt values sent via `openclaw gateway call agent`. */
   extraSystemPrompts(): string[];
+  /** Get all agent models sent via `openclaw gateway call agent`. */
+  agentModels(): string[];
   /** Get all session patches. */
   sessionPatches(): Array<{ key: string; model: string; label?: string }>;
   /** Reset captured commands. */
@@ -83,6 +87,9 @@ function createCommandInterceptor(): {
             if (params.extraSystemPrompt) {
               captured.extraSystemPrompt = params.extraSystemPrompt;
             }
+            if (params.model) {
+              captured.agentModel = params.model;
+            }
           }
           if (rpcMethod === "sessions.patch") {
             captured.sessionPatch = { key: params.key, model: params.model, label: params.label };
@@ -110,6 +117,11 @@ function createCommandInterceptor(): {
       return commands
         .filter((c) => c.extraSystemPrompt !== undefined)
         .map((c) => c.extraSystemPrompt!);
+    },
+    agentModels() {
+      return commands
+        .filter((c) => c.agentModel !== undefined)
+        .map((c) => c.agentModel!);
     },
     sessionPatches() {
       return commands


### PR DESCRIPTION
## Problem

`sendToAgent()` was not passing the resolved model to the `openclaw gateway call agent` RPC. While `sessions.patch` correctly set the model on the session, the agent invocation itself inherited the parent agent's default model — silently ignoring workflow.yaml config.

This caused every subagent to run on the parent's expensive default (e.g. Opus) instead of the configured model (e.g. Haiku/Sonnet).

## Fix

Pass the resolved model through to the gateway agent call:

- `lib/dispatch/session.ts`: Added `model?` to `sendToAgent` opts, spread into RPC params
- `lib/dispatch/index.ts`: Pass the already-resolved `model` variable to `sendToAgent`
- `lib/testing/harness.ts`: Capture `agentModel` from agent RPC calls for test assertions
- `lib/services/pipeline.e2e.test.ts`: New test verifying model propagates to both `sessions.patch` and `agent` RPC

## Test

```
ok 2 - should pass resolved model in agent RPC call (#436)
```

Addresses issue #436