### PR TITLE
Fix: Pass runtime to projectTick in heartbeat for notification delivery

### DIFF
--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -144,6 +144,7 @@ export async function tick(opts: {
         pluginConfig,
         maxPickups: remaining,
         instanceName,
+        runtime,
         runCommand,
       });
 


### PR DESCRIPTION
## Root Cause

The heartbeat tick runner (`lib/services/heartbeat/tick-runner.ts`) was not forwarding the `PluginRuntime` to `projectTick()`. This caused the entire dispatch chain to receive `runtime=undefined`:

```
heartbeat tick() → tick-runner projectTick() → dispatchTask() → notify()
                    ↑ runtime NOT passed here
```

Without `runtime`, `notify()` cannot use the direct channel API (`sendMessageTelegram`, `sendMessageDiscord`, etc.) and falls back to the CLI messaging path, which may fail or be unavailable in certain contexts.

## Impact

This affected **all heartbeat-dispatched tasks**, not just architect research tasks. However, architect research tasks are more visibly affected because:
1. Research tasks are often queued (architect busy) and later picked up by heartbeat
2. Direct dispatch via `research_task()` correctly passes `runtime` — only the heartbeat path was broken

Related to #453 (heartbeat notifications failing with 'runCommand is required when runtime is not available').

## Fix

One-line fix: add `runtime` to the `projectTick()` call in `tick-runner.ts`.

```diff
 const tickResult = await projectTick({
   workspaceDir,
   projectSlug: slug,
   agentId,
   pluginConfig,
   maxPickups: remaining,
   instanceName,
+  runtime,
   runCommand,
 });
```

## Verification

- TypeScript compiles cleanly
- `runtime` was already available in scope (passed to `tick()` from the heartbeat service)
- All other callers of `dispatchTask()` (`research_task`, `task_start`) already pass `runtime`

Addresses issue #465