### PR TITLE
Prevent state label loss during PR feedback transitions

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -242,6 +242,22 @@ export class GitHubProvider implements IssueProvider {
       for (const l of currentStateLabels) args.push("--remove-label", l);
       await this.gh(args);
     }
+
+    // Post-transition validation: verify exactly one state label remains (#473)
+    try {
+      const postIssue = await this.getIssue(issueId);
+      const postStateLabels = postIssue.labels.filter((l) => stateLabels.includes(l));
+      if (postStateLabels.length !== 1 || !postStateLabels.includes(to)) {
+        // Log anomaly but don't throw — transition is already committed
+        console.error(
+          `[state_transition_anomaly] Issue #${issueId}: expected state "${to}", ` +
+          `found ${postStateLabels.length} state label(s): [${postStateLabels.join(", ")}]. ` +
+          `Transition: "${from}" → "${to}". See #473.`,
+        );
+      }
+    } catch {
+      // Validation is best-effort — don't break the transition
+    }
   }
 
   async addLabel(issueId: number, label: string): Promise<void> {

--- a/lib/services/heartbeat/passes.ts
+++ b/lib/services/heartbeat/passes.ts
@@ -7,6 +7,7 @@ import { type Project } from "../../projects/index.js";
 import {
   checkWorkerHealth,
   scanOrphanedLabels,
+  scanStatelessIssues,
   type SessionLookup,
 } from "./health.js";
 import { reviewPass } from "./review.js";
@@ -60,6 +61,17 @@ export async function performHealthPass(
     });
     fixedCount += orphanFixes.filter((f) => f.fixed).length;
   }
+
+  // Scan for stateless issues (managed issues that lost their state label — #473)
+  const statelessFixes = await scanStatelessIssues({
+    workspaceDir,
+    projectSlug,
+    project,
+    provider,
+    autoFix: true,
+    instanceName,
+  });
+  fixedCount += statelessFixes.filter((f) => f.fixed).length;
 
   return fixedCount;
 }


### PR DESCRIPTION
## Problem

Issue #470 lost its workflow state label during a PR feedback transition, becoming invisible to the heartbeat queue scanner. Root cause analysis in #473 identified that `removeLabels()` calls in the dispatch pipeline could accidentally remove state labels when cleaning up role/routing labels.

## Solution

Three-layer defense:

### Phase 1: State Label Protection in Dispatch ✅
- Added `filterNonStateLabels()` helper that strips state labels from any array passed to `removeLabels()`
- All three `removeLabels()` calls in dispatch (role labels, review routing, test routing) now filter through it
- State labels are **exclusively** managed by `transitionLabel()` — never by generic label cleanup

### Phase 2: Post-Transition Validation ✅
- Both GitHub and GitLab `transitionLabel()` methods now validate after completion
- Checks exactly one state label exists (the target label) after both add and remove phases
- Anomalies logged via `console.error` with full context for debugging
- Best-effort — never throws or blocks the transition

### Phase 3: Stateless Issue Recovery via Health Pass ✅
- New `scanStatelessIssues()` function detects open, managed issues with zero state labels
- Identifies managed issues by presence of workflow labels (`developer:*`, `review:*`, `owner:*`, etc.)
- Auto-fix: restores to initial state (Planning) so operator can re-triage
- Audit logging for all recoveries
- Respects instance ownership filtering

## Files Changed
- `lib/dispatch/index.ts` — State label filtering + helper
- `lib/providers/github.ts` — Post-transition validation
- `lib/providers/gitlab.ts` — Post-transition validation  
- `lib/services/heartbeat/health.ts` — `scanStatelessIssues()` function
- `lib/services/heartbeat/passes.ts` — Integrated into health pass

## Testing
- TypeScript compiles cleanly
- Defensive by design: all new code is best-effort (never blocks existing flows)
- Existing health pass, dispatch, and transition logic unchanged in happy path

Addresses issue #475, fixes #470, implements recommendations from #473