### PR TITLE
feat: add issueComplete notification on issue close

### DIFF
--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -85,6 +85,14 @@ export type NotifyEvent =
       issueUrl: string;
       issueTitle: string;
       prUrl?: string;
+    }
+  | {
+      type: "issueComplete";
+      project: string;
+      issueId: number;
+      issueUrl: string;
+      issueTitle: string;
+      prUrl?: string;
     };
 
 /**
@@ -243,6 +251,15 @@ function buildMessage(event: NotifyEvent): string {
       if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
       msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       msg += `\n→ Moving to To Improve for developer attention`;
+      return msg;
+    }
+
+    case "issueComplete": {
+      let msg = `🏁 Issue completed: #${event.issueId} — ${event.issueTitle}`;
+      msg += `\n📦 Project: ${event.project}`;
+      if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
+      msg += `\n✅ Issue closed — work delivered.`;
       return msg;
     }
   }

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -212,6 +212,27 @@ export async function executeCompletion(opts: {
     switch (action) {
       case Action.CLOSE_ISSUE:
         await provider.closeIssue(issueId);
+        // Notify that the issue has been fully completed and closed
+        notify(
+          {
+            type: "issueComplete",
+            project: projectName,
+            issueId,
+            issueUrl: issue.web_url,
+            issueTitle: issue.title,
+            prUrl,
+          },
+          {
+            workspaceDir,
+            config: notifyConfig,
+            channelId: notifyTarget?.channelId,
+            channel: notifyTarget?.channel ?? "telegram",
+            runtime,
+            accountId: notifyTarget?.accountId,
+          },
+        ).catch((err) => {
+          auditLog(workspaceDir, "pipeline_warning", { step: "issueCompleteNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
+        });
         break;
       case Action.REOPEN_ISSUE:
         await provider.reopenIssue(issueId);


### PR DESCRIPTION
## Summary

- Adds new `issueComplete` notification event type to the NotifyEvent union
- Adds `buildMessage` handler for `issueComplete` with project context and delivery confirmation
- Emits `issueComplete` notification in `executeCompletion` when `CLOSE_ISSUE` action fires

## Motivation

The DevClaw pipeline has notifications for worker start, completion, PR merge, and review routing — but none for the final delivery milestone when an issue is closed. This makes it hard to know when a task has been fully delivered without checking GitHub directly.

## Backward compatibility

- New event type — no breaking changes
- `issueComplete` defaults to enabled (like all other event types)
- Can be suppressed via `notifications.issueComplete: false` in plugin config

## Test plan

- [x] Build succeeds (`npm run build`)
- [ ] `issueComplete` notification fires when tester passes and issue closes
- [ ] Notification content includes project name, issue link, and PR link