### PR TITLE
fix(context): safely resolve runCommand with fallbacks for OpenClaw 2…

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -32,11 +32,34 @@ export type PluginContext = {
 };
 
 /**
+ * Resolve the runCommand function from whichever API path exists.
+ * OpenClaw 2026.5.3-1+ moved runCommandWithTimeout; try several paths.
+ */
+function resolveRunCommand(api: OpenClawPluginApi): RunCommand {
+  const candidate =
+    (api as any).runtime?.system?.runCommandWithTimeout ??
+    (api as any).system?.runCommand ??
+    (api as any).runCommandWithTimeout ??
+    (api as any).runCommand;
+
+  if (candidate) return candidate;
+
+  // Stub so the plugin registers but surfaces a clear error on first use.
+  return ((...args: unknown[]) => {
+    throw new Error(
+      "[DevClaw] runCommand is unavailable — none of the known API paths " +
+        "(runtime.system.runCommandWithTimeout, system.runCommand, " +
+        "runCommandWithTimeout, runCommand) exist on the provided plugin API.",
+    );
+  }) as unknown as RunCommand;
+}
+
+/**
  * Build a PluginContext from the raw plugin API. Called once in register().
  */
 export function createPluginContext(api: OpenClawPluginApi): PluginContext {
   return {
-    runCommand: api.runtime.system.runCommandWithTimeout,
+    runCommand: resolveRunCommand(api),
     runtime: api.runtime,
     pluginConfig: api.pluginConfig as Record<string, unknown> | undefined,
     config: api.config,


### PR DESCRIPTION
…026.5.3+

Fixes a plugin registration crash:
"TypeError: Cannot read properties of undefined (reading 'runCommandWithTimeout')" which occurs on newer OpenClaw core versions due to changes in the plugin API.

- Added `resolveRunCommand` in `lib/context.ts` to probe multiple API paths:
  1. `api.runtime.system.runCommandWithTimeout`
  2. `api.system.runCommand`
  3. `api.runCommandWithTimeout`
  4. `api.runCommand`
- Implemented a safe fallback stub that logs a meaningful error if none of the above are found, preventing immediate plugin startup failures.